### PR TITLE
Add models for playerTeams, add some scripts to support it, calculate…

### DIFF
--- a/BackEnd/package-lock.json
+++ b/BackEnd/package-lock.json
@@ -33,6 +33,7 @@
         "@types/express": "^4.17.13",
         "@types/node-fetch": "^2.6.1",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
+        "csv-parse": "^5.4.0",
         "eslint": "^8.40.0",
         "eslint-config-standard-with-typescript": "^34.0.1",
         "eslint-plugin-import": "^2.27.5",
@@ -1667,6 +1668,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.4.0.tgz",
+      "integrity": "sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg==",
+      "dev": true
     },
     "node_modules/date-fns": {
       "version": "2.28.0",
@@ -7046,6 +7053,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
+    "csv-parse": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.4.0.tgz",
+      "integrity": "sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg==",
       "dev": true
     },
     "date-fns": {

--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -27,7 +27,8 @@
     "eslint-plugin-react": "^7.32.2",
     "nodemon": "^2.0.15",
     "ts-node": "^10.7.0",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "csv-parse": "^5.4.0"
   },
   "dependencies": {
     "@types/cookie-parser": "^1.4.3",

--- a/BackEnd/scripts/addTeamsToGameModel.ts
+++ b/BackEnd/scripts/addTeamsToGameModel.ts
@@ -1,0 +1,45 @@
+import dotenv from 'dotenv';
+dotenv.config({ path: '../.env.development' });
+import { ensureConnection, SaveObjects } from '../src/db/dbConnect';
+import PlayerGameModel from '../../Common/models/playergame.model';
+import PlayerTeamModel from '../../Common/models/playerteam.model';
+import { getDbPlayerTeamPlayerPuuid } from '../src/db/playerteam';
+
+// Only using these 3 seasons for backfill since its the only one where i can garuntee the rosters/names are up to date
+const validSeasons: number[] = [17, 18, 19]; // ramp, unst, dom
+async function addTeamsToGameModel(seasonId: number) {
+  await ensureConnection();
+  let playerGames = await PlayerGameModel.find({ where: { seasonId: seasonId } });
+  let noTeamCount = 0;
+  for (let game of playerGames) {
+    console.log(`Updating Game ${game.gameGameId}, Player ${game.playerPuuid}, Season: ${game.seasonId}`);
+    let team = await getTeam(seasonId, game.playerPuuid);
+
+    if (team == null) {
+      game.risenTeamId = team;
+    } else {
+      noTeamCount++;
+    }
+  }
+
+  console.log(`Teamless ${noTeamCount}`);
+  console.log('Saving Games');
+  await SaveObjects(playerGames);
+}
+
+async function getTeam(seasonId: number, puuid: string) :  Promise<number> {
+  let teamModel = await PlayerTeamModel.findOne({ where: { seasonId: seasonId, playerPuuid: puuid } });
+  if (!teamModel) {
+    return null;
+  }
+  return teamModel.teamId;
+}
+
+async function run() {
+  for (let season of validSeasons) {
+    console.log(`Loading Season ${season}`);
+    await addTeamsToGameModel(season);
+  }
+}
+
+run();

--- a/BackEnd/scripts/generateTeamModel.ts
+++ b/BackEnd/scripts/generateTeamModel.ts
@@ -1,0 +1,130 @@
+import dotenv from 'dotenv';
+dotenv.config({ path: '../.env.development' });
+import TeamModel from '../../Common/models/team.model';
+import { ensureConnection, SaveObjects } from '../src/db/dbConnect';
+import PlayerTeamModel from '../../Common/models/playerteam.model';
+import { parse } from 'csv-parse/sync';
+import * as fs from 'fs';
+import { GetOrCreatePlayerOverviewByName } from '../src/business/player';
+
+const path = require('path');
+
+type RisenSheetRow = {
+  teamName: string,
+  abrv: string,
+  win: number
+  loss: number
+  top: string
+  jungle: string,
+  mid: string,
+  adc: string,
+  support: string,
+  sub1: string,
+  sub2: string,
+  sub3: string,
+  sub4: string,
+  sub5: string
+  multigg: string
+};
+
+async function buildTeam(seasonId: number, displayName: string, abbreviation: string, win: number, loss: number, opgg: string) {
+  await ensureConnection();
+  if(await findTeam(displayName, abbreviation, seasonId)) {
+    console.log(`the team: ${displayName} already exists! Skipping`);
+    return;
+  }
+
+  let teamToAdd = TeamModel.create({
+    seasonId: seasonId,
+    displayName: displayName,
+    win: 0,
+    loss: 0,
+    abbreviation: abbreviation,
+    wonSeason: false,
+    opgg: opgg,
+  });
+
+  let rows : TeamModel[] = [];
+  rows.push(teamToAdd);
+
+  await SaveObjects(rows, TeamModel);
+}
+
+async function buildPlayersInTeams(seasonId: number, teamId: number, playersNames: string[]) {
+  await ensureConnection();
+
+  let playerPuuids: string[] = [];
+
+  for (let player of playersNames) {
+    console.log(`Trying to load player ${player}`);
+    try {
+      let playerModel = await GetOrCreatePlayerOverviewByName(player);
+      playerPuuids.push(playerModel.puuid);
+    } catch (e) {
+      console.log(`Couldnt Find [${player}] skipping`);
+    }
+  }
+
+  // Generate the players on the team
+  let rows : PlayerTeamModel[] = [];
+  for (let puuid of playerPuuids) {
+    let playerToAdd = PlayerTeamModel.create({
+      playerPuuid: puuid,
+      seasonId: seasonId,
+      teamId: teamId,
+    });
+    rows.push(playerToAdd);
+  }
+
+  console.log('Saving PLayers');
+  await SaveObjects(rows, PlayerTeamModel);
+}
+
+async function addLeague(seasonId: number, sheet: string) {
+  let rows: RisenSheetRow[] = parseSheet(sheet);
+
+  // Generate the team;
+  for (let row of rows) {
+    await buildTeam(seasonId, row.teamName, row.abrv, row.win, row.loss, row.multigg);
+  }
+
+  console.log('Finished Generating The Team');
+
+  // Add the players
+  for (let row of rows) {
+    let team = await findTeam(row.teamName, row.abrv, seasonId);
+    let playerNames = [row.top, row.jungle, row.mid, row.adc, row.support, row.sub1, row.sub2, row.sub3, row.sub4, row.sub5].filter(name => '' !== name);
+    await buildPlayersInTeams(seasonId, team.teamId, playerNames);
+  }
+
+  console.log('Finished Adding Players');
+}
+
+async function findTeam(teamName: string, ABBR: string, seasonId: number): Promise<TeamModel> {
+  await ensureConnection();
+  return await TeamModel.findOne({ where: { displayName: teamName, abbreviation: ABBR, seasonId: seasonId  } });
+}
+
+function parseSheet(sheetPath: String): RisenSheetRow[] {
+  const csvFilePath = path.resolve(__dirname, sheetPath);
+
+  const headers = ['teamName', 'abrv', 'W', 'L', 'top', 'jungle', 'mid', 'adc', 'support', 'sub1', 'sub2','sub3','sub4', 'sub5', 'multigg'];
+
+  const fileContent = fs.readFileSync(csvFilePath, { encoding: 'utf-8' });
+
+  return parse(fileContent, {
+    delimiter: ',',
+    columns: headers,
+    fromLine: 2,
+    cast: (columnValue, context) => {
+      if (context.column === 'W' || context.column === 'L') {
+        return parseInt(columnValue, 10);
+      }
+      return columnValue;
+    },
+  });
+}
+
+let sheet = 'Rampage2023.csv'; // Needs to be in same dir as this file
+let seasonId= 17;
+addLeague(seasonId, sheet);

--- a/BackEnd/scripts/generateTeamModel.ts
+++ b/BackEnd/scripts/generateTeamModel.ts
@@ -41,7 +41,6 @@ async function buildTeam(seasonId: number, displayName: string, abbreviation: st
     loss: 0,
     abbreviation: abbreviation,
     wonSeason: false,
-    opgg: opgg,
   });
 
   let rows : TeamModel[] = [];

--- a/BackEnd/src/db/dbConnect.ts
+++ b/BackEnd/src/db/dbConnect.ts
@@ -12,6 +12,9 @@ import PlayerChampionStatsModel from '../../../Common/models/playerchampionstats
 import PlayerStatModel from '../../../Common/models/playerstat.model';
 import { toSearchName } from '../../../Common/utils';
 import DenylistModel from '../../../Common/models/denylist.model';
+import PlayerTeamModel from '../../../Common/models/playerteam.model';
+import TeamModel from '../../../Common/models/team.model';
+import AggregatedPlayerStatModel from '../../../Common/models/aggregatedplayerstat.model';
 
 const POSTGRES_URI = process.env.POSTGRES_URI;
 export const ALL_TOURNAMENT_GAMES_NAME = 'ALL TOURNAMENT GAMES'; // DO NOT TOUCH
@@ -46,6 +49,9 @@ const options = {
       PlayerChampionStatsModel,
       PlayerStatModel,
       DenylistModel,
+      PlayerTeamModel,
+      TeamModel,
+      AggregatedPlayerStatModel,
     ]
   }
 };

--- a/BackEnd/src/db/games.ts
+++ b/BackEnd/src/db/games.ts
@@ -20,7 +20,7 @@ const roleOrder = [
 ];
 
 export function CreateDbPlayerGameNoSave(riotPlayer: RiotParticipantDto, gameObj: GameModel,
-  timelineStats: TimelineParticipantStats, teamStats: TeamSumStat, seasonId: number, lobbyOrder: number): PlayerGameModel {
+  timelineStats: TimelineParticipantStats, teamStats: TeamSumStat, seasonId: number, lobbyOrder: number, teamId?: number): PlayerGameModel {
 
   if (!riotPlayer.challenges) {
     const d = new Date(0);
@@ -28,16 +28,17 @@ export function CreateDbPlayerGameNoSave(riotPlayer: RiotParticipantDto, gameObj
     logger.warn(`Game ${gameObj.gameId} has no challenge stats. Probably too old. Game start: ${d.toUTCString()}`);
   }
 
+
   const shortPlayerData = {
     game: gameObj,
     timestamp: gameObj.gameStart,
     timestampAdded: GetCurrentEpcohMs(),
 
     playerPuuid: riotPlayer.puuid,
+    risenTeamId: !!teamId ? teamId : null,
 
     championId: riotPlayer.championId,
     teamId: riotPlayer.teamId,
-
     seasonId,
 
     championTransform: riotPlayer.championTransform,

--- a/BackEnd/src/db/playerteam.ts
+++ b/BackEnd/src/db/playerteam.ts
@@ -1,0 +1,16 @@
+import { ensureConnection } from './dbConnect';
+import { FindManyOptions } from 'typeorm';
+import PlayerTeamModel from '../../../Common/models/playerteam.model';
+
+export async function getDbPlayerTeamPlayerPuuid(playerPuuid: string, seasonId: number): Promise<number> {
+  await ensureConnection();
+    
+  const searchFilter: FindManyOptions<PlayerTeamModel> = { where: { playerPuuid: playerPuuid, seasonId: seasonId } };
+  let playerTeam = await PlayerTeamModel.findOne(searchFilter);
+  // playerTeams wont return anything if we pass in the ALL_RISEN_SEASON_ID
+  if (!playerTeam) {
+    return null;
+  }
+
+  return playerTeam.teamId;
+}

--- a/Common/models/aggregatedplayerstat.model.ts
+++ b/Common/models/aggregatedplayerstat.model.ts
@@ -1,0 +1,626 @@
+import {BaseEntity, Column, Entity, Index, ManyToOne, PrimaryColumn} from "typeorm";
+import PlayerModel from "./player.model";
+import SeasonModel from "./season.model";
+import TeamModel from "./team.model";
+
+// This class is temporarily a duplicate of playerstat.model.ts while we duplicate over to
+@Entity({ name: "aggregated_player_stat_model" })
+export default class AggregatedPlayerStatModel extends BaseEntity
+{
+    @PrimaryColumn('text')
+    playerPuuid: string;
+
+    // Duplicated from game for filtering
+    @Index()
+    @PrimaryColumn('integer')
+    seasonId: number;
+
+    @PrimaryColumn('text')
+    lobbyPosition: string;
+
+    @ManyToOne(() => PlayerModel, { eager: true })
+    player: PlayerModel;
+
+    @ManyToOne(() => SeasonModel)
+    season: SeasonModel;
+
+    @Index()
+    @Column("integer")
+    championId: number
+
+    @ManyToOne(() => TeamModel)
+    team: TeamModel
+    @Column("integer")
+    teamId: number
+
+    @Column("integer")
+    games: number;
+
+    // Base Stats
+    @Column("integer")
+    kills: number;
+
+    @Column("integer")
+    deaths: number;
+
+    @Column("integer")
+    assists: number;
+
+    @Column("integer")
+    champLevel: number;
+
+    @Column("real")
+    win: number;
+
+    // Combat
+    @Column("integer")
+    kills15: number;
+
+    @Column("integer")
+    deaths15: number;
+
+    @Column("integer")
+    assists15: number;
+
+    // Income
+    @Column("integer")
+    goldEarned: number;
+
+    @Column("integer")
+    goldSpent: number;
+
+    @Column("integer")
+    totalMinionsKilled: number;
+
+    @Column("integer")
+    neutralMinionsKilled: number;
+
+    // Damage
+    @Column("integer")
+    physicalDamageDealtToChampions: number;
+
+    @Column("integer")
+    magicDamageDealtToChampions: number;
+
+    @Column("integer")
+    trueDamageDealtToChampions: number;
+
+    @Column("integer")
+    totalDamageDealtToChampions: number;
+
+    @Column("integer")
+    physicalDamageTaken: number;
+
+    @Column("integer")
+    magicalDamageTaken: number;
+
+    @Column("integer")
+    trueDamageTaken: number;
+
+    @Column("integer")
+    totalDamageTaken: number;
+
+    @Column("integer")
+    damageSelfMitigated: number;
+
+    @Column("integer")
+    totalHeal: number;
+
+    @Column("integer")
+    totalHealsOnTeammates: number;
+
+    @Column("integer")
+    totalDamageShieldedOnTeammates: number;
+
+    // Vision
+    @Column("integer")
+    visionScore: number;
+
+    @Column("integer")
+    wardsPlaced15: number;
+
+    @Column("integer")
+    wardsPlaced: number;
+
+    @Column("integer")
+    wardsKilled15: number;
+
+    @Column("integer")
+    wardsKilled: number;
+
+    @Column("integer")
+    visionWardsBoughtInGame: number;
+
+    // Objectives
+    @Column("integer")
+    damageDealtToObjectives: number;
+
+    @Column("integer")
+    dragonKills: number;
+
+    @Column("real")
+    firstTowerTakedown: number;
+
+    @Column("real")
+    firstBloodTakedown: number;
+
+    // Fun
+    @Column("real")
+    firstBloodKill: number;
+
+    @Column("real")
+    firstBloodAssist: number;
+
+    @Column("real")
+    firstTowerKill: number;
+
+    @Column("real")
+    firstTowerAssist: number;
+
+    @Column("integer")
+    turretKills: number;
+
+    @Column("integer")
+    doubleKills: number;
+
+    @Column("integer")
+    tripleKills: number;
+
+    @Column("integer")
+    quadraKills: number;
+
+    @Column("integer")
+    pentaKills: number;
+
+    @Column("integer")
+    consumablesPurchased: number;
+
+    // Pings
+    @Column('integer')
+    allInPings: number;
+
+    @Column('integer')
+    assistMePings: number;
+
+    @Column('integer')
+    baitPings: number;
+
+    @Column('integer')
+    basicPings: number;
+
+    @Column('integer')
+    enemyMissingPings: number;
+
+    @Column('integer')
+    enemyVisionPings: number;
+
+    @Column('integer')
+    getBackPings: number;
+
+    @Column('integer')
+    holdPings: number;
+
+    @Column('integer')
+    needVisionPings: number;
+
+    @Column('integer')
+    onMyWayPings: number;
+
+    @Column('integer')
+    pushPings: number;
+
+    @Column('integer')
+    visionClearedPings: number;
+
+    @Column('integer')
+    commandPings: number;
+
+    @Column('integer')
+    dangerPings: number;
+
+    // Challenges
+    @Column("integer")
+    "12AssistStreakCount": number;
+
+    @Column("integer")
+    abilityUses: number;
+
+    @Column("integer")
+    acesBefore15Minutes: number;
+
+    @Column("real")
+    alliedJungleMonsterKills: number;
+
+    @Column("integer")
+    baronTakedowns: number;
+
+    @Column("integer")
+    blastConeOppositeOpponentCount: number;
+
+    @Column("integer")
+    bountyGold: number;
+
+    @Column("integer")
+    buffsStolen: number;
+
+    @Column("real")
+    completeSupportQuestInTime: number;
+
+    @Column("real")
+    controlWardTimeCoverageInRiverOrEnemyHalf: number;
+
+    @Column("integer")
+    controlWardsPlaced: number;
+
+    @Column("real")
+    damagePerMinute: number;
+
+    @Column("real")
+    damageTakenOnTeamPercentage: number;
+
+    @Column("real")
+    dancedWithRiftHerald: number;
+
+    @Column("integer")
+    deathsByEnemyChamps: number;
+
+    @Column("integer")
+    dodgeSkillShotsSmallWindow: number;
+
+    @Column("integer")
+    doubleAces: number;
+
+    @Column("integer")
+    dragonTakedowns: number;
+
+    @Column("real")
+    earliestBaron: number;
+
+    @Column("real")
+    earliestDragonTakedown: number;
+
+    @Column("real")
+    earlyLaningPhaseGoldExpAdvantage: number;
+
+    @Column("real")
+    effectiveHealAndShielding: number;
+
+    @Column("integer")
+    elderDragonKillsWithOpposingSoul: number;
+
+    @Column("integer")
+    elderDragonMultikills: number;
+
+    @Column("integer")
+    enemyChampionImmobilizations: number;
+
+    @Column("real")
+    enemyJungleMonsterKills: number;
+
+    @Column("integer")
+    epicMonsterKillsNearEnemyJungler: number;
+
+    @Column("integer")
+    epicMonsterKillsWithin30SecondsOfSpawn: number;
+
+    @Column("integer")
+    epicMonsterSteals: number;
+
+    @Column("integer")
+    epicMonsterStolenWithoutSmite: number;
+
+    @Column("integer")
+    flawlessAces: number;
+
+    @Column("integer")
+    fullTeamTakedown: number;
+
+    @Column("real")
+    gameLength: number;
+
+    @Column("real")
+    getTakedownsInAllLanesEarlyJungleAsLaner: number;
+
+    @Column("real")
+    goldPerMinute: number;
+
+    @Column("real")
+    hadAfkTeammate: number;
+
+    @Column("real")
+    hadOpenNexus: number;
+
+    @Column("integer")
+    immobilizeAndKillWithAlly: number;
+
+    @Column("integer")
+    initialBuffCount: number;
+
+    @Column("integer")
+    initialCrabCount: number;
+
+    @Column("real")
+    jungleCsBefore10Minutes: number;
+
+    @Column("integer")
+    junglerKillsEarlyJungle: number;
+
+    @Column("integer")
+    junglerTakedownsNearDamagedEpicMonster: number;
+
+    @Column("integer")
+    kTurretsDestroyedBeforePlatesFall: number;
+
+    @Column("real")
+    kda: number;
+
+    @Column("integer")
+    killAfterHiddenWithAlly: number;
+
+    @Column("real")
+    killParticipation: number;
+
+    @Column("integer")
+    killedChampTookFullTeamDamageSurvived: number;
+
+    @Column("integer")
+    killsNearEnemyTurret: number;
+
+    @Column("integer")
+    killsOnLanersEarlyJungleAsJungler: number;
+
+    @Column("integer")
+    killsOnOtherLanesEarlyJungleAsLaner: number;
+
+    @Column("integer")
+    killsOnRecentlyHealedByAramPack: number;
+
+    @Column("integer")
+    killsUnderOwnTurret: number;
+
+    @Column("integer")
+    killsWithHelpFromEpicMonster: number;
+
+    @Column("integer")
+    knockEnemyIntoTeamAndKill: number;
+
+    @Column("integer")
+    landSkillShotsEarlyGame: number;
+
+    @Column("integer")
+    laneMinionsFirst10Minutes: number;
+
+    @Column("real")
+    laningPhaseGoldExpAdvantage: number;
+
+    @Column("integer")
+    legendaryCount: number;
+
+    @Column("integer")
+    lostAnInhibitor: number;
+
+    @Column("real")
+    maxCsAdvantageOnLaneOpponent: number;
+
+    @Column("integer")
+    maxKillDeficit: number;
+
+    @Column("real")
+    maxLevelLeadLaneOpponent: number;
+
+    @Column("real")
+    moreEnemyJungleThanOpponent: number;
+
+    @Column("integer")
+    multiKillOneSpell: number;
+
+    @Column("integer")
+    multiTurretRiftHeraldCount: number;
+
+    @Column("integer")
+    multikills: number;
+
+    @Column("integer")
+    multikillsAfterAggressiveFlash: number;
+
+    @Column("integer")
+    mythicItemUsed: number;
+
+    @Column("integer")
+    outerTurretExecutesBefore10Minutes: number;
+
+    @Column("integer")
+    outnumberedKills: number;
+
+    @Column("integer")
+    outnumberedNexusKill: number;
+
+    @Column("integer")
+    perfectDragonSoulsTaken: number;
+
+    @Column("real")
+    perfectGame: number;
+
+    @Column("integer")
+    pickKillWithAlly: number;
+
+    @Column("integer")
+    poroExplosions: number;
+
+    @Column("integer")
+    quickCleanse: number;
+
+    @Column("integer")
+    quickFirstTurret: number;
+
+    @Column("integer")
+    quickSoloKills: number;
+
+    @Column("integer")
+    riftHeraldTakedowns: number;
+
+    @Column("integer")
+    saveAllyFromDeath: number;
+
+    @Column("integer")
+    scuttleCrabKills: number;
+
+    @Column("integer")
+    skillshotsDodged: number;
+
+    @Column("integer")
+    skillshotsHit: number;
+
+    @Column("integer")
+    snowballsHit: number;
+
+    @Column("integer")
+    soloBaronKills: number;
+
+    @Column("integer")
+    soloKills: number;
+
+    @Column("integer")
+    soloTurretsLategame: number;
+
+    @Column("integer")
+    stealthWardsPlaced: number;
+
+    @Column("integer")
+    survivedSingleDigitHpCount: number;
+
+    @Column("integer")
+    survivedThreeImmobilizesInFight: number;
+
+    @Column("integer")
+    takedownOnFirstTurret: number;
+
+    @Column("integer")
+    takedowns: number;
+
+    @Column("integer")
+    takedownsAfterGainingLevelAdvantage: number;
+
+    @Column("integer")
+    takedownsBeforeJungleMinionSpawn: number;
+
+    @Column("integer")
+    takedownsFirst25Minutes: number;
+
+    @Column("integer")
+    takedownsInAlcove: number;
+
+    @Column("integer")
+    takedownsInEnemyFountain: number;
+
+    @Column("integer")
+    teamBaronKills: number;
+
+    @Column("real")
+    teamDamagePercentage: number;
+
+    @Column("integer")
+    teamElderDragonKills: number;
+
+    @Column("integer")
+    teamRiftHeraldKills: number;
+
+    @Column("integer")
+    teleportTakedowns: number;
+
+    @Column("integer")
+    threeWardsOneSweeperCount: number;
+
+    @Column("integer")
+    tookLargeDamageSurvived: number;
+
+    @Column("integer")
+    turretPlatesTaken: number;
+
+    @Column("integer")
+    turretTakedowns: number;
+
+    @Column("integer")
+    turretsTakenWithRiftHerald: number;
+
+    @Column("integer")
+    twentyMinionsIn3SecondsCount: number;
+
+    @Column("integer")
+    unseenRecalls: number;
+
+    @Column("real")
+    visionScoreAdvantageLaneOpponent: number;
+
+    @Column("real")
+    visionScorePerMinute: number;
+
+    @Column("integer")
+    wardTakedowns: number;
+
+    @Column("integer")
+    wardTakedownsBefore20M: number;
+
+    @Column("integer")
+    wardsGuarded: number;
+
+    // Team Totals
+    @Column("real")
+    totalKillsOfTeam: number
+
+    @Column("real")
+    totalDeathsOfTeam: number
+
+    @Column("real")
+    totalAssistsOfTeam: number
+
+    @Column("real")
+    totalDamageDealtToObjectivesOfTeam: number
+
+    @Column("real")
+    totalGoldOfTeam: number
+
+    @Column("real")
+    totalPhysicalDamageDealtToChampionsOfTeam: number
+
+    @Column("real")
+    totalMagicDamageDealtToChampionsOfTeam: number
+
+    @Column("real")
+    totalTrueDamageDealtToChampionsOfTeam: number
+
+    @Column("real")
+    totalDamageDealtToChampionsOfTeam: number
+
+    @Column("real")
+    totalVisionScoreOfTeam: number
+
+    //Diffs
+    @Column("integer")
+    xpDiff: number
+
+    @Column("integer")
+    xpDiff15: number
+
+    @Column("integer")
+    xpDiff25: number
+
+    @Column("integer")
+    goldDiff: number
+
+    @Column("integer")
+    goldDiff15: number
+
+    @Column("integer")
+    goldDiff25: number
+
+    @Column("integer")
+    csDiff: number;
+
+    @Column("integer")
+    csDiff15: number;
+
+    @Column("integer")
+    csDiff25: number;
+
+}

--- a/Common/models/playerteam.model.ts
+++ b/Common/models/playerteam.model.ts
@@ -1,0 +1,15 @@
+import {BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryColumn} from "typeorm";
+import PlayerModel from "./player.model";
+
+@Entity({ name: "player_team_model" })
+export default class PlayerTeamModel extends BaseEntity {
+
+    @ManyToOne(() => PlayerModel)
+    player: PlayerModel;
+    @PrimaryColumn('text')
+    playerPuuid: string;
+    @PrimaryColumn("integer")
+    seasonId: number
+    @PrimaryColumn("integer")
+    teamId: number
+}

--- a/Common/models/playerteam.model.ts
+++ b/Common/models/playerteam.model.ts
@@ -1,5 +1,5 @@
-import {BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryColumn} from "typeorm";
-import PlayerModel from "./player.model";
+import {BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryColumn} from 'typeorm';
+import PlayerModel from './player.model';
 
 @Entity({ name: "player_team_model" })
 export default class PlayerTeamModel extends BaseEntity {

--- a/Common/models/team.model.ts
+++ b/Common/models/team.model.ts
@@ -16,9 +16,6 @@ export default class TeamModel extends BaseEntity {
     loss: number
     @Column("text")
     abbreviation: string
-    @Column("text")
-    opgg: string
     @Column("boolean")
     wonSeason: boolean
-
 }

--- a/Common/models/team.model.ts
+++ b/Common/models/team.model.ts
@@ -1,0 +1,24 @@
+import {BaseEntity, Column, Entity, Index, PrimaryColumn, PrimaryGeneratedColumn} from "typeorm";
+
+@Entity({ name: "team_model" })
+export default class TeamModel extends BaseEntity {
+
+    @PrimaryGeneratedColumn()
+    teamId: number
+    @Index()
+    @PrimaryColumn("integer")
+    seasonId: number
+    @Column("text")
+    displayName: string
+    @Column("integer")
+    win: number
+    @Column("integer")
+    loss: number
+    @Column("text")
+    abbreviation: string
+    @Column("text")
+    opgg: string
+    @Column("boolean")
+    wonSeason: boolean
+
+}


### PR DESCRIPTION
Mostly model changes + scripts.

## Notes;
- Just 1 change to add the team to the player game model.
- As a FYI the data in the player_team_model table and team_model is loaded manually by the `generateTeamModel.ts` script
- aggregated_player_stat_model will replace `player_stat_model` and `payerchampionstats`. Technically it shouldnt be part of this PR but I would have to change my dbconnect file and im lazy so im including it in here. 

## Testing
i didnt really test that the player_game_model data was created correctly when a game came in, so we will have to monitor to make sure something isnt blowing up. I tested that the `getDbPlayerTeamPlayerPuuid` works correctly tho, so it should be fine. 


