### PR TITLE
Deprecate use of PlayerChampionModel by frontend

### DIFF
--- a/BackEnd/src/api/player.ts
+++ b/BackEnd/src/api/player.ts
@@ -1,6 +1,6 @@
 import express, { Request, Router } from 'express';
 import { TypedRequest, TypedResponse } from '../../../Common/Interface/Internal/responseUtil';
-import { PlayerChampionStatsRequest, PlayerChampionStatsResponse, PlayerGamesResponse, PlayerOverviewResponse, PlayerSeasonsResponse, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
+import { PlayerGamesResponse, PlayerOverviewResponse, PlayerSeasonsResponse, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
 import { GetOrCreatePlayerOverviewByName, GetPlayerDetailedGames, GetPlayerSeasons, UpdateGamesByPlayerPuuid } from '../business/player';
 import logger from '../../logger';
 import { DocumentNotFound } from '../../../Common/errors';
@@ -8,7 +8,6 @@ import { NonNone } from '../../../Common/utils';
 import { GetGamesRequest } from '../../../Common/Interface/Internal/games';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
 import { CreatePlayerStatsByPuuid } from '../business/playerstats';
-import { GetDBChampionStatsByPlayerPuuid } from '../db/playerstats';
 
 const router: Router = express.Router();
 
@@ -43,19 +42,6 @@ router.post('/summary/by-name/:playerName', async(req: Request, res: TypedRespon
     } else {
       res.status(500).send('Something went wrong');
     }
-  }
-});
-
-router.post('/champions/by-puuid/:playerPuuid', async(req:TypedRequest<PlayerChampionStatsRequest>, res: TypedResponse<PlayerChampionStatsResponse>) => {
-  logger.info(`Getting champion stats for player: ${req.params.playerPuuid}`);
-  try {
-    const champData = await GetDBChampionStatsByPlayerPuuid(req.params.playerPuuid, req.body.seasonId,  GameRoles[req.body.roleId as keyof typeof GameRoles], req.body.risenOnly);
-    res.json({
-      champions: champData
-    });
-  } catch (error) {
-    logger.error(error);
-    res.status(500).send('Something went wrong');
   }
 });
 

--- a/BackEnd/src/business/player.ts
+++ b/BackEnd/src/business/player.ts
@@ -8,12 +8,8 @@ import { SaveDataByMatchId } from './games';
 import { PlayerDetailedGame, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
 import logger from '../../logger';
 import { GetDbGamesByGameIds, GetDbPlayerGamesByPlayerPuuid } from '../db/games';
-import PlayerChampionStatsModel from '../../../Common/models/playerchampionstats.model';
-import { NonNone, roundTo } from '../../../Common/utils';
-import { ALL_RISEN_GAMES_ID, ALL_TOURNAMENT_GAMES_ID, SaveObjects } from '../db/dbConnect';
 import { ApiError } from '../external-api/_call';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
-import PlayerGameModel from '../../../Common/models/playergame.model';
 
 export async function GetOrCreatePlayerOverviewByName(playerName: string): Promise<PlayerModel> {
   try {

--- a/BackEnd/src/db/playerstats.ts
+++ b/BackEnd/src/db/playerstats.ts
@@ -1,9 +1,7 @@
-import { ALL_RISEN_GAMES_ID, ALL_TOURNAMENT_GAMES_ID, ensureConnection } from './dbConnect';
-import PlayerStatModel from '../../../Common/models/playerstat.model';
+import { ALL_RISEN_GAMES_ID, ensureConnection } from './dbConnect';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
-import { FindManyOptions, IsNull, MoreThan, Not } from 'typeorm';
+import { FindManyOptions } from 'typeorm';
 import AggregatedPlayerStatModel from '../../../Common/models/aggregatedplayerstat.model';
-import PlayerChampionStatsModel from '../../../Common/models/playerchampionstats.model';
 
 export async function GetDbAggregatedPlayerStatsByPlayerPuuid(playerPuuid: string, teamId?: number, championId?: number, seasonId?: number, roleId?: GameRoles): Promise<AggregatedPlayerStatModel[]> {
   await ensureConnection();
@@ -37,60 +35,4 @@ export async function GetDbAggregatedPlayerStatsByPlayerPuuid(playerPuuid: strin
   }
 
   return await AggregatedPlayerStatModel.find(searchFilter);
-}
-
-// TODO remove this function when the frontend starts using AggregatedPlayerStatModel
-export async function GetDBChampionStatsByPlayerPuuid(playerPuuid: string, seasonId?: number, roleId?: GameRoles, risenOnly?: boolean): Promise<PlayerChampionStatsModel[]> {
-  await ensureConnection();
-  let playerStats = await GetDbAggregatedPlayerStatsByPlayerPuuid(playerPuuid,
-    null,
-    null,
-    seasonId ? seasonId : ( risenOnly ? ALL_RISEN_GAMES_ID : ALL_TOURNAMENT_GAMES_ID ),
-    roleId);
-  let mergedPlayerStats: Map<String, AggregatedPlayerStatModel> = new Map<String, AggregatedPlayerStatModel>();
-
-  for (let playerStat of playerStats) {
-    const key = `${playerPuuid}-${seasonId}-${roleId}-${playerStat.championId}`;
-    if(mergedPlayerStats.has(key)) {
-      let model = mergedPlayerStats.get(key);
-      for (let key of Object.keys(model)) {
-        // @ts-ignore
-        if(typeof model[key] === 'string') {
-          continue;
-        }
-        // @ts-ignore
-        model[key] += playerStat[key];
-      }
-      mergedPlayerStats.set(key, model);
-    } else {
-      mergedPlayerStats.set(key, playerStat);
-    }
-  }
-
-  let playerChampionStatsModels: PlayerChampionStatsModel[] = [];
-  for (let mergedPlayerStat of mergedPlayerStats.values()) {
-    let model = PlayerChampionStatsModel.create({
-      championId: mergedPlayerStat.championId,
-      position: mergedPlayerStat.lobbyPosition,
-      playerPuuid,
-      seasonId: seasonId,
-      totalAssists: mergedPlayerStat.assists,
-      totalDeaths: mergedPlayerStat.deaths,
-      totalKills: mergedPlayerStat.kills,
-      totalMinionsKilled: mergedPlayerStat.totalMinionsKilled,
-      totalNeutralMinionsKilled: mergedPlayerStat.neutralMinionsKilled,
-      totalGames: mergedPlayerStat.games,
-      totalWins: mergedPlayerStat.win,
-      averageDamageDealt: (mergedPlayerStat.physicalDamageDealtToChampions + mergedPlayerStat.magicDamageDealtToChampions + mergedPlayerStat.trueDamageDealtToChampions) / mergedPlayerStat.games,
-      averageDamageTaken: (mergedPlayerStat.physicalDamageTaken + mergedPlayerStat.magicalDamageTaken + mergedPlayerStat.trueDamageTaken) / mergedPlayerStat.games,
-      totalDoubleKills: mergedPlayerStat.doubleKills,
-      totalTripleKills: mergedPlayerStat.tripleKills,
-      totalQuadraKills: mergedPlayerStat.quadraKills,
-      totalPentaKills: mergedPlayerStat.pentaKills,
-      averageGameDuration: mergedPlayerStat.gameLength / mergedPlayerStat.games,
-      averageGoldEarned: mergedPlayerStat.goldEarned / mergedPlayerStat.games
-    });
-    playerChampionStatsModels.push(model);
-  }
-  return playerChampionStatsModels;
 }

--- a/Common/Interface/Internal/player.ts
+++ b/Common/Interface/Internal/player.ts
@@ -1,8 +1,6 @@
 import PlayerGameModel from "../../models/playergame.model";
 import PlayerModel from "../../models/player.model";
 import GameModel from "../../models/game.model";
-import PlayerChampionStatsModel from "../../models/playerchampionstats.model";
-import { GameRoles } from "../General/gameEnums";
 
 export interface PlayerOverviewResponse {
   overview: PlayerModel
@@ -20,16 +18,6 @@ export interface PlayerDetailedGame {
 export interface UpdatePlayerGamesResponse {
   updatedGames: GameModel[];
   failedUpdateGameIds: string[];
-}
-
-export interface PlayerChampionStatsResponse {
-  champions: PlayerChampionStatsModel[];
-}
-
-export interface PlayerChampionStatsRequest {
-  seasonId?: number;
-  risenOnly?: boolean;
-  roleId?: GameRoles;
 }
 
 export interface PlayerSeasonsResponse {

--- a/Common/models/playerchampionstats.model.ts
+++ b/Common/models/playerchampionstats.model.ts
@@ -1,4 +1,3 @@
-import { GameRoles } from "../Interface/General/gameEnums";
 import { BaseEntity, Column, Entity, Index, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 import PlayerModel from "./player.model";
 import SeasonModel from "./season.model";

--- a/front-end/src/api/leaderboards.ts
+++ b/front-end/src/api/leaderboards.ts
@@ -1,8 +1,6 @@
-import { PlayerChampionStatsRequest } from '../../../Common/Interface/Internal/player';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
 import { MakeBackendCall } from './_call';
 import { GetLeaderboardRequest, GetLeaderboardResponse } from '../../../Common/Interface/Internal/leaderboard';
-import PlayerStatModel from '../../../Common/models/playerstat.model';
 import AggregatedPlayerStatModel from '../../../Common/models/aggregatedplayerstat.model';
 
 export async function getFlattenedLeaderboard(seasonId?: number, risenOnly?: boolean, roleId?: string, collapseRoles?: boolean) : Promise<AggregatedPlayerStatModel[]> {

--- a/front-end/src/api/player.ts
+++ b/front-end/src/api/player.ts
@@ -1,8 +1,7 @@
-import { PlayerChampionStatsRequest, PlayerChampionStatsResponse, PlayerGamesResponse, PlayerOverviewResponse, PlayerSeasonsResponse, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
+import { PlayerGamesResponse, PlayerOverviewResponse, PlayerSeasonsResponse, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
 import { GetGamesRequest, GetGamesResponse } from '../../../Common/Interface/Internal/games';
 import { MakeBackendCall } from './_call';
 import { GetPlayerStatsRequest, GetPlayerStatsResponse } from '../../../Common/Interface/Internal/playerstats';
-import { GameRoles } from '../../../Common/Interface/General/gameEnums';
 
 export async function GetPlayerProfile(playerName: string): Promise<PlayerOverviewResponse> {
   return await MakeBackendCall(`/api/player/summary/by-name/${playerName}`, 'POST', {}) as PlayerOverviewResponse;
@@ -50,11 +49,6 @@ export async function UpdatePlayer(playerPuuid: string): Promise<UpdatePlayerGam
     method: 'POST'
   });
   return (await data.json()) as UpdatePlayerGamesResponse;
-}
-
-export async function GetPlayerChampionStats(playerPuuid: string, seasonId?: number, risenOnly?: boolean, roleId?: string): Promise<PlayerChampionStatsResponse> {
-  const role = GameRoles[roleId as keyof typeof GameRoles];
-  return await MakeBackendCall<PlayerChampionStatsRequest>(`/api/player/champions/by-puuid/${playerPuuid}`, 'POST', { seasonId, risenOnly, roleId: role }) as PlayerChampionStatsResponse;
 }
 
 export async function GetPlayerStats(playerPuuid: string, seasonId?: number, roleId?: string, teamId?: number, championId?: number, risenOnly?: boolean): Promise<GetPlayerStatsResponse> {

--- a/front-end/src/components/champion-overview/champion-overview.tsx
+++ b/front-end/src/components/champion-overview/champion-overview.tsx
@@ -1,24 +1,27 @@
 import { useTheme } from '@emotion/react';
-import { Box, Divider, SxProps, Theme, Typography } from '@mui/material';
+import { Box, SxProps, Theme } from '@mui/material';
 import React from 'react';
-import PlayerChampionStatsModel from '../../../../Common/models/playerchampionstats.model';
 import BaseRisenBox from '../risen-box/base-risen-box';
 import ChampionSummaryBox from './champion-summary-box';
+import AggregatedPlayerStatModel from '../../../../Common/models/aggregatedplayerstat.model';
+
 
 
 interface ChampionOverviewProps {
-    championData: PlayerChampionStatsModel[]
+    playerStats: AggregatedPlayerStatModel[]
     sx?: SxProps<Theme>;
 }
 
 export default function ChampionOverview(championOverviewProps: ChampionOverviewProps) {
   const theme = useTheme() as Theme;
 
+  championOverviewProps.playerStats.sort((a, b) => {return b.games - a.games;});
+
   return (
     <BaseRisenBox title="CHAMPIONS" sx={championOverviewProps.sx}>
       <Box sx={{ display: 'flex', columnGap: 1, rowGap: 1, flexWrap: 'wrap' }}>
-        { championOverviewProps.championData.map((champData, index) =>
-          <ChampionSummaryBox key={index} championData={champData}/>
+        { championOverviewProps.playerStats.map((champData, index) =>
+          <ChampionSummaryBox key={index} championId={champData.championId} games={champData.games}/>
         )}
       </Box>
     </BaseRisenBox>

--- a/front-end/src/components/champion-overview/champion-summary-box.tsx
+++ b/front-end/src/components/champion-overview/champion-summary-box.tsx
@@ -1,24 +1,23 @@
 import { useTheme } from '@emotion/react';
-import { Box, Grow, Theme, Typography } from '@mui/material';
+import { Theme } from '@mui/material';
 import React from 'react';
-import PlayerChampionStatsModel from '../../../../Common/models/playerchampionstats.model';
 import ImgBox from '../risen-box/img-box';
 
 interface ChampionSummaryBoxProps {
-    championData: PlayerChampionStatsModel
+    championId: number;
+    games: number
 }
-
 
 export default function ChampionSummaryBox(championOverviewProps: ChampionSummaryBoxProps) {
   const theme = useTheme() as Theme;
   return (
     <ImgBox
       sx={{ height:55, width: 55 }}
-      alt={`${championOverviewProps.championData.championId}`}
-      src={`/images/champions/icons/${championOverviewProps.championData.championId}_0.png`}
+      alt={`${championOverviewProps.championId}`}
+      src={`/images/champions/icons/${championOverviewProps.championId}_0.png`}
       height="50px"
       width="50px"
-      text={championOverviewProps.championData.totalGames.toString()}
+      text={championOverviewProps.games.toString()}
     />
   );
 }

--- a/front-end/src/components/player-page/champions.tsx
+++ b/front-end/src/components/player-page/champions.tsx
@@ -1,16 +1,19 @@
 import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
 import React from 'react';
-import PlayerChampionStatsModel from '../../../../Common/models/playerchampionstats.model';
-import { calculateChampionKDA, calculateWR, riotTimestampToGameTime, toPerMinute } from '../../../../Common/utils';
+import {
+  riotTimestampToGameTime,
+  roundTo,
+} from '../../../../Common/utils';
 import { ChampionIdToName } from '../../common/utils';
 import WinRatePieChart from '../charts/winrate-pie';
 import SeasonModel from '../../../../Common/models/season.model';
 import { GameRoles } from '../../../../Common/Interface/General/gameEnums';
-import GamesFilter from '../filters/games-filter';
 import FilterBar from '../filters/filter-bar';
+import AggregatedPlayerStatModel from '../../../../Common/models/aggregatedplayerstat.model';
+import { StatGenerators } from '../../common/constants';
 
 interface Props {
-  championData: PlayerChampionStatsModel[]
+  playerStats: AggregatedPlayerStatModel[]
   seasonConfig: {
     seasonId: string,
     setSeasonId: (seasonId: string) => void,
@@ -23,6 +26,9 @@ interface Props {
 }
 
 export default function PlayerPageChampions(props: Props) {
+
+  props.playerStats.sort((a, b) => {return b.games - a.games;});
+
   return (
     <Box>
       <FilterBar seasonConfig={props.seasonConfig} roleConfig={props.roleConfig}/>
@@ -55,8 +61,8 @@ export default function PlayerPageChampions(props: Props) {
           </TableHead>
           <TableBody>
             {
-              props.championData.map((champData: PlayerChampionStatsModel) => {
-                const gameTime = Number.parseInt(champData.averageGameDuration.toString());
+              props.playerStats.map((champData: AggregatedPlayerStatModel) => {
+                const gameTime = Number.parseInt(champData.gameLength.toString());
                 return (
                   <TableRow key={champData.championId}>
                     <TableCell>
@@ -69,25 +75,25 @@ export default function PlayerPageChampions(props: Props) {
                     </TableCell>
                     <TableCell>
                       <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-                        <WinRatePieChart wins={champData.totalWins} losses={champData.totalGames - champData.totalWins} height={25}></WinRatePieChart>
-                        <Typography sx={{ pl: 1 }}>{calculateWR(champData, 2)}%</Typography>
+                        <WinRatePieChart wins={champData.win} losses={champData.games - champData.win} height={25}></WinRatePieChart>
+                        <Typography sx={{ pl: 1 }}>{roundTo(StatGenerators.WR.getStatValue(champData))}%</Typography>
                       </Box>
                       {/* In Progress */}
                     </TableCell>
                     <TableCell>
-                      <Typography align="center">{calculateChampionKDA(champData, 2)}:1</Typography>
+                      <Typography align="center">{StatGenerators.KDA.getStatString([champData])}:1</Typography>
                     </TableCell>
                     <TableCell>
                       <Typography align="center">{riotTimestampToGameTime(gameTime)}</Typography>
                     </TableCell>
                     <TableCell>
-                      <Typography align="center">{toPerMinute(champData.averageDamageDealt, gameTime)}</Typography>
+                      <Typography align="center">{StatGenerators.DPM.getStatString([champData])}</Typography>
                     </TableCell>
                     <TableCell>
-                      <Typography align="center">{toPerMinute(champData.averageGoldEarned, gameTime)}</Typography>
+                      <Typography align="center">{StatGenerators.GPM.getStatString([champData])}</Typography>
                     </TableCell>
                     <TableCell>
-                      <Typography align="center">{champData.totalGames}</Typography>
+                      <Typography align="center">{champData.games}</Typography>
                     </TableCell>
                   </TableRow>
                 );

--- a/front-end/src/components/player-page/general.tsx
+++ b/front-end/src/components/player-page/general.tsx
@@ -21,7 +21,6 @@ interface Props {
   player?: PlayerModel,
   seasons: SeasonModel[],
   playerStats: AggregatedPlayerStatModel[],
-  championData: PlayerChampionStatsModel[],
   loadGamesConfig: {
     callback: (newPlayer: boolean) => void,
     status: boolean,
@@ -45,7 +44,7 @@ const StyledFlexBox = styled(Box)(({ theme }) => ({
   'align-content': 'flex-start',
 }));
 
-function PlayerPageGeneral({ games, loadGamesConfig, player, seasons, championData, playerStats }: Props)
+function PlayerPageGeneral({ games, loadGamesConfig, player, seasons, playerStats }: Props)
 {
   games = games ?? [];
   const results = { wins: 0, losses: 0 };
@@ -60,7 +59,7 @@ function PlayerPageGeneral({ games, loadGamesConfig, player, seasons, championDa
         <StyledFlexBox>
           <RankFlag sx={{ minWidth: '170px', flexGrow: 1 }} player={player}></RankFlag>
           <WinRateBox hasData={results.wins > 0 || results.losses > 0} {...results} />
-          <ChampionOverview championData={championData}  sx={{ width: '100%' }}/>
+          <ChampionOverview playerStats={playerStats}  sx={{ width: '100%' }}/>
           {/* <PlayedSeasons playerPuuid={player?.puuid} setSeason={loadGamesConfig.seasonConfig.setSeasonId} allSeasons={seasons} /> */}
           <Hidden smDown>
             <RecentPlayers sx={{ width: '100%' }} recentGames={games} />

--- a/front-end/src/components/player-page/general.tsx
+++ b/front-end/src/components/player-page/general.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Grid, Box, Hidden, FormControl, InputLabel, Select, MenuItem, SelectChangeEvent, styled, useTheme, useMediaQuery } from '@mui/material';
+import { Box, Hidden, styled, useTheme, useMediaQuery } from '@mui/material';
 import GameSummaryList from './game-summary/game-summary-list';
 import RankFlag from './general-components/rank-flag';
 import { PlayerDetailedGame } from '../../../../Common/Interface/Internal/player';
@@ -7,13 +7,10 @@ import PlayerModel from '../../../../Common/models/player.model';
 
 import SeasonModel from '../../../../Common/models/season.model';
 import { GameRoles } from '../../../../Common/Interface/General/gameEnums';
-import PlayerChampionStatsModel from '../../../../Common/models/playerchampionstats.model';
 import ChampionOverview from '../champion-overview/champion-overview';
 import WinRateBox from '../charts/win-rate-box';
-import PlayerStatModel from '../../../../Common/models/playerstat.model';
 import FilterBar from '../filters/filter-bar';
 import RecentPlayers from '../recent-players/recentPlayers';
-import PlayedSeasons from '../played-seasons/playedSeasons';
 import AggregatedPlayerStatModel from '../../../../Common/models/aggregatedplayerstat.model';
 
 interface Props {

--- a/front-end/src/components/player-page/stats.tsx
+++ b/front-end/src/components/player-page/stats.tsx
@@ -3,16 +3,14 @@ import { Box, Typography, } from '@mui/material';
 import PerformanceOverview from './stats/performance-overview';
 import SeasonModel from '../../../../Common/models/season.model';
 import ChampionOverview from '../champion-overview/champion-overview';
-import PlayerChampionStatsModel from '../../../../Common/models/playerchampionstats.model';
 import WinRateBox from '../charts/win-rate-box';
 import BaseRisenBox from '../risen-box/base-risen-box';
 import { GameRoles } from '../../../../Common/Interface/General/gameEnums';
-import PlayerStatModel from '../../../../Common/models/playerstat.model';
 import FilterBar from '../filters/filter-bar';
 import ObjectiveOverview from './stats/objective-overview';
 import GameRatingOverview from './stats/game-rating-overview';
 import PingOverview from './stats/ping-overview';
-import { combine, deepCopy, doesPlayerStatsObjectHaveData } from '../../../../Common/utils';
+import { deepCopy, doesPlayerStatsObjectHaveData, mergePlayerStats } from '../../../../Common/utils';
 import AggregatedPlayerStatModel from '../../../../Common/models/aggregatedplayerstat.model';
 
 interface PlayerPageStatsProps {
@@ -25,31 +23,34 @@ interface PlayerPageStatsProps {
         roleId: GameRoles,
         setRoleId: (roleId: GameRoles) => void,
     };
-    championData: PlayerChampionStatsModel[]
     playerStats: AggregatedPlayerStatModel[]
     leaderboardData?: AggregatedPlayerStatModel[]
     playerPuuid?: string
 }
 
+const byRole = (seasonId: string, roleId: GameRoles, teamId: number, championId: number) => {
+  return `${seasonId}-${roleId}-${championId}`;
+};
+
 export default function PlayerPageStats(props: PlayerPageStatsProps) {
   const {
     seasonConfig,
     roleConfig,
-    championData,
+    playerStats,
     playerPuuid,
     leaderboardData,
   } = props;
 
   // This page does not care about a per champion breakdown right now, so merge the data so its by role.
   // This page also doesnt care about a per team breakdown right now, so merge the team data away
-  let playerStats = deepCopy(props.playerStats); // DeepCopy is needed for some react state BS
+  let playerStatsByRole = deepCopy(props.playerStats); // DeepCopy is needed for some react state BS
   if (roleConfig) {
-    playerStats = mergePlayerStats(seasonConfig.seasonId, roleConfig?.roleId, playerStats);
+    playerStatsByRole = mergePlayerStats(seasonConfig.seasonId, roleConfig.roleId, deepCopy(playerStats), byRole);
   }
 
   let wins = 0;
   let games = 0;
-  for (let playerStat of playerStats) {
+  for (let playerStat of playerStatsByRole) {
     wins += playerStat.win;
     games += playerStat.games;
   }
@@ -59,19 +60,19 @@ export default function PlayerPageStats(props: PlayerPageStatsProps) {
       <FilterBar seasonConfig={seasonConfig} roleConfig={roleConfig}/>
       <Box sx={{ display: 'flex', flexDirection: 'row', columnGap: 3 }}>
         <Box sx={{ maxWidth: 280, display: 'flex', flexDirection: 'column', rowGap: 2 }}>
-          <WinRateBox hasData={doesPlayerStatsObjectHaveData(playerStats)} wins={wins} losses={games-wins}/>
-          <ChampionOverview championData={championData}/>
-          <ObjectiveOverview playerStats={playerStats}/>
+          <WinRateBox hasData={doesPlayerStatsObjectHaveData(playerStatsByRole)} wins={wins} losses={games-wins}/>
+          <ChampionOverview playerStats={playerStats}/>
+          <ObjectiveOverview playerStats={playerStatsByRole}/>
         </Box>
         <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 2 }}>
-          <PerformanceOverview    playerStats={playerStats}
+          <PerformanceOverview    playerStats={playerStatsByRole}
             playerPuuid={playerPuuid}
             leaderboardStats={leaderboardData ?? []}
           />
           <Box sx={{ minHeight: 350, display: 'flex', flexDirection: 'row', columnGap: 2 }}>
-            <GameRatingOverview playerStats={playerStats}
+            <GameRatingOverview playerStats={playerStatsByRole}
               roleId={!!roleConfig?.roleId ? roleConfig.roleId : GameRoles.ALL}/>
-            <PingOverview playerStats={playerStats}/>
+            <PingOverview playerStats={playerStatsByRole}/>
             <BaseRisenBox hideDivider>
               <Typography variant="subtitle1">THIS SECTION IS COMING SOON</Typography>
               <Typography variant="subtitle1">DM soulbert#7829 with bugs/suggestions</Typography>
@@ -81,19 +82,4 @@ export default function PlayerPageStats(props: PlayerPageStatsProps) {
       </Box>
     </Box>
   );
-}
-
-function mergePlayerStats(seasonId: string, roleId: GameRoles, playerStatsWithChampions: AggregatedPlayerStatModel[]): AggregatedPlayerStatModel[] {
-  let mergedPlayerStats: Map<String, AggregatedPlayerStatModel> = new Map<String, AggregatedPlayerStatModel>();
-
-  for (let playerStat of playerStatsWithChampions) {
-    const key = `${seasonId}-${roleId}`;
-    if(mergedPlayerStats.has(key)) {
-      mergedPlayerStats.set(key, combine(playerStat, mergedPlayerStats.get(key) as AggregatedPlayerStatModel));
-    } else {
-      mergedPlayerStats.set(key, playerStat);
-    }
-  }
-
-  return Array.from(mergedPlayerStats.values());
 }

--- a/front-end/src/components/player-page/stats/performance-overview.tsx
+++ b/front-end/src/components/player-page/stats/performance-overview.tsx
@@ -3,7 +3,6 @@ import StatBox from './stat-box';
 import React from 'react';
 import { useTheme } from '@emotion/react';
 import { BaseStatGenerator } from '../../../common/stats-generators/BaseStatsGenerator';
-import PlayerStatModel from '../../../../../Common/models/playerstat.model';
 import { StatGenerators } from '../../../common/constants';
 import AggregatedPlayerStatModel from '../../../../../Common/models/aggregatedplayerstat.model';
 


### PR DESCRIPTION
As promised, deprecating the frontend use of championData in favor of just using aggregatedPlayerStats. Removal of API code will follow this CR shortly

Tested with Vexrax, Granterino, Soulbert accounts 