### PR TITLE
Improve efficiency of updating teams

### DIFF
--- a/BackEnd/scripts/buildRisenTeams.ts
+++ b/BackEnd/scripts/buildRisenTeams.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+dotenv.config({ path: '../.env.development' });
+import { buildRisenTeams } from '../src/business/teams';
+
+buildRisenTeams(19);

--- a/BackEnd/scripts/generateTeamModel.ts
+++ b/BackEnd/scripts/generateTeamModel.ts
@@ -148,10 +148,8 @@ function parseSheet(sheetPath: String): RisenSheetRow[] {
   });
 }
 
-// let sheets = [ { s: 'Dominate2023.csv', id: 19 }, { s:'Rampage2023.csv', id: 17 }, { s: 'Unstoppable2023.csv', id: 18 }]; // Needs to be in same dir as this file
+let sheets = [ { s: 'Dominate2023.csv', id: 19 }, { s:'Rampage2023.csv', id: 17 }, { s: 'Unstoppable2023.csv', id: 18 }]; // Needs to be in same dir as this file
 
-// for (let sheet of sheets) {
-//   addLeague(sheet.id, sheet.s);
-// }
-buildRisenTeams();
-console.log("wheee");
+for (let sheet of sheets) {
+  addLeague(sheet.id, sheet.s);
+}

--- a/BackEnd/src/business/teams.ts
+++ b/BackEnd/src/business/teams.ts
@@ -42,9 +42,9 @@ export async function GetTeamsBySeasonId(seasonId: number): Promise<TeamModel[]>
   return await GetDbteamsBySeasonId(seasonId);
 }
 
-export async function buildRisenTeams() {
+export async function buildRisenTeams(seasonId: number) {
   let sheetName = 'Teams and Standings';
-  let seasonsWithSheets = await GetDbActiveSeasonWithSheets();
+  let seasonsWithSheets = await GetDbActiveSeasonWithSheets(seasonId);
   for (let seasonsWithSheet of seasonsWithSheets) {
     let sheet = await GetGoogleSheet(seasonsWithSheet.googleSheetId, sheetName);
     let parser: RisenSheetParser = parsers.get(seasonsWithSheet.googleSheetParserType);

--- a/BackEnd/src/db/season.ts
+++ b/BackEnd/src/db/season.ts
@@ -47,7 +47,12 @@ export async function GetDbSeasonById(id: number): Promise<SeasonModel> {
   return obj;
 }
 
-export async function GetDbActiveSeasonWithSheets(): Promise<SeasonModel[]> {
+export async function GetDbActiveSeasonsWithSheets(): Promise<SeasonModel[]> {
   await ensureConnection();
   return await SeasonModel.find({ where: { active: true, googleSheetId: Not(IsNull()), googleSheetParserType: Not(IsNull()) } });
+}
+
+export async function GetDbActiveSeasonWithSheets(seasonId: number): Promise<SeasonModel[]> {
+  await ensureConnection();
+  return await SeasonModel.find({ where: { active: true, id: seasonId, googleSheetId: Not(IsNull()), googleSheetParserType: Not(IsNull()) } });
 }


### PR DESCRIPTION
This PR does two things
- Makes it so we only update the teams for the season we need
- Make the teams actually update after a match, (currently the update code would never actually be hit after a new match was completed)
- Also cleans up the scripts a bit