### PR TITLE
Fix team transfer bug

### DIFF
--- a/BackEnd/scripts/buildRisenTeams.ts
+++ b/BackEnd/scripts/buildRisenTeams.ts
@@ -2,4 +2,12 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '../.env.development' });
 import { buildRisenTeams } from '../src/business/teams';
 
-buildRisenTeams(19);
+/*
+    22 - champions
+    23 - Diviine
+    24 - draft
+    25 - dom
+    26 - unstop
+    27 - ramp
+ */
+buildRisenTeams(27);

--- a/BackEnd/src/business/teams.ts
+++ b/BackEnd/src/business/teams.ts
@@ -128,11 +128,18 @@ export async function addPlayersToTeams(seasonId: number, risenSheetTeam: RisenT
         teamSeasonId: seasonId,
         teamTeamId: team.teamId,
       });
+      rows.push(playerToAdd);
+    } else if(playerToAdd.teamTeamId !== team.teamId) {
+      // We need to remove and the add here because for some reason updating the row always try to insert a new row.
+      await playerToAdd.remove();
+      playerToAdd = PlayerTeamModel.create({
+        playerPuuid: puuid,
+        teamSeasonId: seasonId,
+        teamTeamId: team.teamId,
+      });
+      logger.info(`Player ${playerToAdd.playerPuuid} teamId updated, creating a new row`);
+      rows.push(playerToAdd);
     }
-
-    playerToAdd.teamSeasonId = seasonId;
-    playerToAdd.teamTeamId = team.teamId;
-    rows.push(playerToAdd);
   }
 
   await SaveObjects(rows, PlayerTeamModel);

--- a/Common/models/playerteam.model.ts
+++ b/Common/models/playerteam.model.ts
@@ -1,9 +1,10 @@
-import {BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryColumn} from 'typeorm';
+import {BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryColumn, Unique} from 'typeorm';
 import PlayerModel from './player.model';
 import SeasonModel from "./season.model";
 import TeamModel from "./team.model";
 
 @Entity({ name: "player_team_model" })
+@Unique(["teamSeasonId", "playerPuuid"])
 export default class PlayerTeamModel extends BaseEntity {
 
     @ManyToOne(() => PlayerModel)


### PR DESCRIPTION
Fixing some backend bugs:
- Fixes the edge case where a user transfers teams within a league. previously this wouldn't update the row but create a new one resulting in a player having two teams for a given league. This would cause some issues on the league page and when loading new matches.
- Also optimizes the saving to DB a little so we only save when needed.
- Also added a constraint to the table so we error instead of creating the row.
- Please dont kill this branch when merging, gonna do a bug bash and fix a bunch of stuff
- Please deploy this ASAP