### PR TITLE
Handle tag line search

### DIFF
--- a/BackEnd/src/api/championstats.ts
+++ b/BackEnd/src/api/championstats.ts
@@ -1,6 +1,5 @@
 import express, { Response, Router } from 'express';
 import { TypedRequest } from '../../../Common/Interface/Internal/responseUtil';
-import { CreatePlayerRadarWithName } from '../business/charts';
 import logger from '../../logger';
 import { ChampionStatsSheetRequest } from '../../../Common/Interface/Internal/championstats';
 import { GetChampionStatsBySeason } from '../business/championstats';

--- a/BackEnd/src/api/charts.ts
+++ b/BackEnd/src/api/charts.ts
@@ -9,7 +9,7 @@ const router: Router = express.Router();
 router.post('/radar', async(req: TypedRequest<RadarChartsRequest>, res: Response) => {
   logger.info(`Call to radar for: ${req.body.playerNames}`);
   try {
-    res.send(await CreatePlayerRadarWithName('Earleking'));
+    res.send(await CreatePlayerRadarWithName('Earleking#NA1'));
   } catch (error) {
     logger.error(error);
   }

--- a/BackEnd/src/api/games.ts
+++ b/BackEnd/src/api/games.ts
@@ -17,7 +17,7 @@ import {
   GetDbPlayerGamesBySeasonId
 } from '../db/games';
 import { RiotMatchCallbackDto } from '../../../Common/Interface/RiotAPI/RiotApiDto';
-import { SaveDataByMatchId, SaveDataByMatchIdAndUpdatePlayerStats } from '../business/games';
+import { SaveDataByMatchIdAndUpdatePlayerStats } from '../business/games';
 import { ToMatchId } from '../../../Common/utils';
 
 const router: Router = express.Router();

--- a/BackEnd/src/api/player.ts
+++ b/BackEnd/src/api/player.ts
@@ -30,7 +30,7 @@ router.post('/update/by-puuid/:playerPuuid', async(req: Request, res: TypedRespo
 
 router.post('/summary/by-name/:playerName', async(req: Request, res: TypedResponse<PlayerOverviewResponse>) => {
   try {
-    const playerNameWithTag = req.params.playerName.replace('-', '#');
+    const playerNameWithTag = req.params.playerName;
     logger.info(`Player summary by name ${playerNameWithTag}`);
     const playerData = await GetOrCreatePlayerOverviewByName(playerNameWithTag);
     res.json({

--- a/BackEnd/src/api/player.ts
+++ b/BackEnd/src/api/player.ts
@@ -29,9 +29,10 @@ router.post('/update/by-puuid/:playerPuuid', async(req: Request, res: TypedRespo
 });
 
 router.post('/summary/by-name/:playerName', async(req: Request, res: TypedResponse<PlayerOverviewResponse>) => {
-  logger.info(`Player summary by name ${req.params.playerName}`);
   try {
-    const playerData = await GetOrCreatePlayerOverviewByName(req.params.playerName);
+    const playerNameWithTag = req.params.playerName.replace('-', '#');
+    logger.info(`Player summary by name ${playerNameWithTag}`);
+    const playerData = await GetOrCreatePlayerOverviewByName(playerNameWithTag);
     res.json({
       overview: playerData
     });

--- a/BackEnd/src/business/games.ts
+++ b/BackEnd/src/business/games.ts
@@ -218,7 +218,10 @@ async function saveMatchForGameAlreadyInDb(matchId: string) {
 
 export async function hasRecentlyBuiltRisenTeams(seasonId: number): Promise<boolean> {
   let season = await GetDbActiveSeasonWithSheets(seasonId);
-  if (!season || !season.lastTimeRisenTeamsBuilt) {
+  if (!season) {
+    return true;
+  }
+  else if (!season.lastTimeRisenTeamsBuilt) {
     return false;
   }
 

--- a/BackEnd/src/business/player.ts
+++ b/BackEnd/src/business/player.ts
@@ -1,5 +1,5 @@
 import {
-  GetRiotPlayerByName,
+  GetRiotAccountByPuuid,
   GetRiotLeagueBySummonerId,
   GetRiotPlayerByPuuid,
   GetRiotPlayerByGameNameAndTagline
@@ -18,7 +18,8 @@ import { GameRoles } from '../../../Common/Interface/General/gameEnums';
 
 export async function GetOrCreatePlayerOverviewByName(playerName: string): Promise<PlayerModel> {
   try {
-    const riotPlayer = await GetRiotPlayerByName(playerName);
+    const [name, tagline] = playerName.split('#'); 
+    const riotPlayer = await GetRiotPlayerByGameNameAndTagline(name, tagline ?? 'NA1');
     if (!riotPlayer) {
       throw new DocumentNotFound(`Player with name ${playerName} not found`);
     }
@@ -65,13 +66,6 @@ export async function GetPlayerOverviewByPuuid(playerPuuid: string): Promise<Pla
   return await GetDbPlayerByPuuid(playerPuuid);
 }
 
-export async function UpdateGamesByPlayerName(playerName: string): Promise<UpdatePlayerGamesResponse> {
-  const player = await GetOrCreatePlayerOverviewByName(playerName);
-  const updatedGames = await UpdateGamesByPlayerObject(player);
-  await UpdatePlayerByPlayerPuuid(player.puuid, updatedGames.updatedGames);
-  return updatedGames;
-}
-
 export async function UpdateGamesByPlayerPuuid(playerPuuid: string): Promise<UpdatePlayerGamesResponse> {
   const player = await GetPlayerOverviewByPuuid(playerPuuid);
   const updatedGames = await UpdateGamesByPlayerObject(player);
@@ -80,10 +74,16 @@ export async function UpdateGamesByPlayerPuuid(playerPuuid: string): Promise<Upd
 }
 
 async function UpdatePlayerByPlayerPuuid(playerPuuid: string, games: GameModel[]): Promise<PlayerModel> {
-  const riotPlayer = await GetRiotPlayerByPuuid(playerPuuid);
+  // We need both the player and the account. The Account contains the new name+tagline info, while the payer
+  // contains all the old data such as level, icon, etc
+  const [riotPlayer, riotAccount] = await Promise.all([
+    GetRiotPlayerByPuuid(playerPuuid),
+    GetRiotAccountByPuuid(playerPuuid),
+  ]);
   return await UpdateDbPlayer(
     playerPuuid,
     riotPlayer,
+    riotAccount,
     await GetRiotLeagueBySummonerId(riotPlayer.id),
     games
   );

--- a/BackEnd/src/business/player.ts
+++ b/BackEnd/src/business/player.ts
@@ -15,10 +15,11 @@ import logger from '../../logger';
 import { GetDbGamesByGameIds, GetDbPlayerGamesByPlayerPuuid } from '../db/games';
 import { ApiError } from '../external-api/_call';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
+import { splitNameTagLine } from '../../../Common/utils';
 
 export async function GetOrCreatePlayerOverviewByName(playerName: string): Promise<PlayerModel> {
   try {
-    const [name, tagline] = playerName.split('#'); 
+    const [name, tagline] = splitNameTagLine(playerName); 
     const riotPlayer = await GetRiotPlayerByGameNameAndTagline(name, tagline ?? 'NA1');
     if (!riotPlayer) {
       throw new DocumentNotFound(`Player with name ${playerName} not found`);

--- a/BackEnd/src/db/player.ts
+++ b/BackEnd/src/db/player.ts
@@ -1,5 +1,5 @@
 import { DocumentNotFound } from '../../../Common/errors';
-import { RiotLeagueEntryDto, RiotParticipantDto, RiotSummonerDto } from '../../../Common/Interface/RiotAPI/RiotApiDto';
+import { RiotAccountDto, RiotLeagueEntryDto, RiotParticipantDto, RiotSummonerDto } from '../../../Common/Interface/RiotAPI/RiotApiDto';
 import GameModel from '../../../Common/models/game.model';
 import PlayerModel from '../../../Common/models/player.model';
 import { GetAveragesFromObjects, GetCurrentEpcohMs, toSearchName } from '../../../Common/utils';
@@ -83,14 +83,15 @@ export async function CreateDbPlayersWithParticipantData(participants: RiotParti
   return playerObjs;
 }
 
-export async function UpdateDbPlayer(playerPuuid: string, player: RiotSummonerDto, soloQLeague: RiotLeagueEntryDto, games: GameModel[]): Promise<PlayerModel> {
+export async function UpdateDbPlayer(playerPuuid: string, player: RiotSummonerDto, account: RiotAccountDto, soloQLeague: RiotLeagueEntryDto, games: GameModel[]): Promise<PlayerModel> {
   await ensureConnection();
   const playerDto = await PlayerModel.findOne({ where: { puuid: playerPuuid } });
   if (!playerDto) {
     throw new DocumentNotFound('Player not found');
   }
   log.debug(`Updating player with riot player: \n ${JSON.stringify(player, null, 2)}`);
-  playerDto.name = player.name;
+  log.debug(`Updating player with riot account: \n ${JSON.stringify(account, null, 2)}`);
+  playerDto.name = `${account.gameName}#${account.tagLine}`;
   playerDto.profileIconId = player.profileIconId ? player.profileIconId : 0;
   playerDto.summonerLevel = player.summonerLevel ? player.summonerLevel : 0;
   playerDto.searchName = toSearchName(player.name);

--- a/BackEnd/src/db/player.ts
+++ b/BackEnd/src/db/player.ts
@@ -8,6 +8,7 @@ import log from '../../logger';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
 import PlayerGameModel from '../../../Common/models/playergame.model';
 import { In } from 'typeorm';
+import { GetRiotAccountByPuuid } from '../external-api/player';
 
 export async function GetDbPlayerByPuuid(playerPuuid: string): Promise<PlayerModel> {
   await ensureConnection();
@@ -29,13 +30,15 @@ export async function getDbPlayerByname(playerName: string): Promise<PlayerModel
 
 export async function CreateDbPlayerWithRiotPlayer(player: RiotSummonerDto, soloQLeague: RiotLeagueEntryDto): Promise<PlayerModel> {
   await ensureConnection();
+  const { gameName, tagLine } = await GetRiotAccountByPuuid(player.puuid);
   const playerDto = PlayerModel.create({
     puuid: player.puuid,
-    name: player.name,
+    name: gameName,
+    tag: tagLine,
     summonerId: player.id,
     profileIconId: player.profileIconId ? player.profileIconId : 0,
     summonerLevel: player.summonerLevel ? player.summonerLevel : 0,
-    searchName: toSearchName(player.name),
+    searchName: toSearchName(gameName, tagLine),
     league: soloQLeague?.tier ? soloQLeague.tier : 'UNRANKED',
     division: soloQLeague?.rank ? soloQLeague.rank : 'I',
     refreshedAt: GetCurrentEpcohMs(),
@@ -62,13 +65,15 @@ export async function CreateDbPlayersWithParticipantData(participants: RiotParti
   for (const participant of participants) {
     const currentPlayer = existingPlayersMap[participant.puuid];
 
+    const { gameName, tagLine } = await GetRiotAccountByPuuid(participant.puuid);
     playerObjs.push(PlayerModel.create({
       puuid: participant.puuid,
-      name: participant.summonerName,
+      name: gameName,
+      tag: tagLine,
       summonerId: participant.summonerId,
       profileIconId: participant.profileIcon ? participant.profileIcon : 0,
       summonerLevel: participant.summonerLevel ? participant.summonerLevel : 0,
-      searchName: toSearchName(participant.summonerName),
+      searchName: toSearchName(gameName, tagLine),
       league: currentPlayer?.league ?? 'UNRANKED',
       division: currentPlayer?.division ?? 'I',
       refreshedAt: currentPlayer?.refreshedAt ?? 0,
@@ -91,10 +96,12 @@ export async function UpdateDbPlayer(playerPuuid: string, player: RiotSummonerDt
   }
   log.debug(`Updating player with riot player: \n ${JSON.stringify(player, null, 2)}`);
   log.debug(`Updating player with riot account: \n ${JSON.stringify(account, null, 2)}`);
-  playerDto.name = `${account.gameName}#${account.tagLine}`;
+
+  playerDto.name = account.gameName;
+  playerDto.tag = account.tagLine;
   playerDto.profileIconId = player.profileIconId ? player.profileIconId : 0;
   playerDto.summonerLevel = player.summonerLevel ? player.summonerLevel : 0;
-  playerDto.searchName = toSearchName(player.name);
+  playerDto.searchName = toSearchName(account.gameName, account.tagLine);
   playerDto.league = soloQLeague?.tier ? soloQLeague.tier : 'UNRANKED';
   playerDto.division = soloQLeague?.rank ? soloQLeague.rank : 'I';
   playerDto.refreshedAt = GetCurrentEpcohMs();

--- a/BackEnd/src/external-api/player.ts
+++ b/BackEnd/src/external-api/player.ts
@@ -1,10 +1,6 @@
 import { RiotAccountDto, RiotLeagueEntryDto, RiotSummonerDto } from '../../../Common/Interface/RiotAPI/RiotApiDto';
 import { MakeRiotAPICall } from './_call';
 
-export async function GetRiotPlayerByName(playerName: string): Promise<RiotSummonerDto> {
-  return await MakeRiotAPICall<RiotSummonerDto>(`/lol/summoner/v4/summoners/by-name/${encodeURIComponent(playerName)}`, 'GET');
-}
-
 export async function GetRiotLeaguesBySummonerId(summonerId: string): Promise<RiotLeagueEntryDto[]> {
   return await MakeRiotAPICall<RiotLeagueEntryDto[]>(`/lol/league/v4/entries/by-summoner/${encodeURIComponent(summonerId)}`, 'GET');
 }
@@ -19,6 +15,10 @@ export async function GetRiotPlayerBySummonerId(summonerId: string): Promise<Rio
 
 export async function GetRiotAccountByGameNameAndTagline(gameName: string, tagline: string): Promise<RiotAccountDto> {
   return await MakeRiotAPICall<RiotAccountDto>(`/riot/account/v1/accounts/by-riot-id/${encodeURIComponent(gameName)}/${encodeURIComponent(tagline)}`, 'GET');
+}
+
+export async function GetRiotAccountByPuuid(puuid: string): Promise<RiotAccountDto> {
+  return await MakeRiotAPICall<RiotAccountDto>(`/riot/account/v1/accounts/by-puuid/${encodeURIComponent(puuid)}`, 'GET');
 }
 
 export async function GetRiotPlayerByGameNameAndTagline(gameName: string, tagline: string): Promise<RiotSummonerDto> {

--- a/Common/models/player.model.ts
+++ b/Common/models/player.model.ts
@@ -12,6 +12,9 @@ export default class PlayerModel extends BaseEntity
   @Column("varchar")
   name: string;
 
+  @Column('varchar', {nullable: true})
+  tag: string;
+
   @Column("int")
   summonerLevel: number;
 

--- a/Common/utils.ts
+++ b/Common/utils.ts
@@ -69,6 +69,13 @@ export function timeToTimeAgo(time: number): string {
 
 }
 
+export function splitNameTagLine(name?: string): string[] {
+  if (!name) {
+    return ['', ''];
+  }
+  return name.split('#');
+}
+
 export function toPerMinute(value: number, riotTimestamp: number, rounded: number = 2): number {
   let m = riotTimestampToMinutes(riotTimestamp);
   return roundTo(value / m, rounded);

--- a/front-end/src/components/header-bar/header-bar.tsx
+++ b/front-end/src/components/header-bar/header-bar.tsx
@@ -53,7 +53,7 @@ export default function HeaderBar({ open, setOpen }: Props) {
 
   function doSearch()
   {
-    const playerName = (document.getElementById(headerSearchId) as HTMLInputElement).value;
+    const playerName = (document.getElementById(headerSearchId) as HTMLInputElement).value.replaceAll('#', '-');
     navigate(`player/${encodeURIComponent(playerName)}`);
   }
 

--- a/front-end/src/components/player-page/header.tsx
+++ b/front-end/src/components/player-page/header.tsx
@@ -29,7 +29,8 @@ export default function PlayerPageHeader(playerOverviewProps: Props)
     }
   }
 
-  const [name, tag] = splitNameTagLine(playerOverviewProps.playerOverview?.overview?.name);
+  const name = playerOverviewProps.playerOverview?.overview?.name;
+  const tag = playerOverviewProps.playerOverview?.overview?.tag;
   const playerIcon = playerOverviewProps.playerOverview?.overview?.profileIconId ? playerOverviewProps.playerOverview?.overview?.profileIconId : 10;
   return (
     <Container sx={{ display: 'flex', alignItems: 'flex-start' }}>

--- a/front-end/src/components/player-page/header.tsx
+++ b/front-end/src/components/player-page/header.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { PlayerOverviewResponse } from '../../../../Common/Interface/Internal/player';
 import { UpdatePlayer } from '../../api/player';
 import LoadingButton from '../loading-button/LoadingButton';
+import { splitNameTagLine } from '../../../../Common/utils';
 
 interface Props {
   playerOverview: PlayerOverviewResponse | undefined;
@@ -28,17 +29,21 @@ export default function PlayerPageHeader(playerOverviewProps: Props)
     }
   }
 
+  const [name, tag] = splitNameTagLine(playerOverviewProps.playerOverview?.overview?.name);
   const playerIcon = playerOverviewProps.playerOverview?.overview?.profileIconId ? playerOverviewProps.playerOverview?.overview?.profileIconId : 10;
   return (
     <Container sx={{ display: 'flex', alignItems: 'flex-start' }}>
       <Box sx={{ display: 'inline-flex', alignItems: 'flex-start' }}>
-        <img src={`https://ddragon.leagueoflegends.com/cdn/12.19.1/img/profileicon/${playerIcon}.png`} className="player-profile-picture"></img>
+        <img src={`https://ddragon.leagueoflegends.com/cdn/13.24.1/img/profileicon/${playerIcon}.png`} className="player-profile-picture"></img>
         <Box sx={{ flexGrow: 1, pl: 2, textAlign: 'left' }}>
           <Hidden mdUp>
-            <Typography variant="h5">{playerOverviewProps.playerOverview?.overview?.name}</Typography>
+            <Typography variant="h5">{name}</Typography><Typography variant="h6">#{tag}</Typography>
           </Hidden>
           <Hidden smDown>
-            <Typography fontFamily="Montserrat" variant="h3" className="text-overflow">{playerOverviewProps.playerOverview?.overview?.name}</Typography>
+            <div>
+              <Typography fontFamily="Montserrat" variant="h3" className="text-overflow inline-flex">{name}</Typography>
+              <Typography fontFamily="Montserrat" variant="h5" className="text-overflow inline-flex">#{tag}</Typography>
+            </div>
           </Hidden>
           {/* <br></br> */}
           <LoadingButton variant="outlined" color="primary" onClick={updateGames} loading={loading}>Update</LoadingButton>

--- a/front-end/src/components/recent-players/recentPlayers.tsx
+++ b/front-end/src/components/recent-players/recentPlayers.tsx
@@ -30,27 +30,31 @@ export default (props: RecentPlayerProps) => {
 
   const teammatesMap: { [key: string]: TeammateStat } = {};
 
+  const puuidToNameMap: { [key: string]: string } = {};
+
   for (const game of recentGames) {
     const teammates = game.playerGame.teamId === 100 ?
       game.game.playersSummary.redPlayers : game.game.playersSummary.bluePlayers;
     teammates.map(player => {
-      if (player.playerName == game.playerGame.player.name) {
+      const puuid = player.playerPuuid;
+      if (puuid == game.playerGame.player.puuid) {
         return;
       }
 
-      if (!(player.playerName in teammatesMap)) {
-        teammatesMap[player.playerName] = {
+      if (!(puuid in teammatesMap)) {
+        teammatesMap[puuid] = {
           games: 0,
           wins: 0,
         };
+        puuidToNameMap[puuid] = player.playerName;
       }
-      teammatesMap[player.playerName].games += 1;
-      teammatesMap[player.playerName].wins += ((game.game.winner ? 100 : 200) === game.playerGame.teamId) ? 1 : 0;
+      teammatesMap[puuid].games += 1;
+      teammatesMap[puuid].wins += ((game.game.winner ? 100 : 200) === game.playerGame.teamId) ? 1 : 0;
     });
   }
 
   const recentPlayerData: {[key in RecentPlayerTableHeaders]: string}[] = Object.entries(teammatesMap).map(([key, value], index) => ({
-    Player: key,
+    Player: puuidToNameMap[key],
     Games: value.games.toString(),
     'W - L': `${value.wins} - ${value.games - value.wins}`,
     'Win Rate': `${roundTo((value.wins / value.games) * 100, 0)}%`,

--- a/front-end/src/pages/search/search.tsx
+++ b/front-end/src/pages/search/search.tsx
@@ -8,7 +8,7 @@ export default function SearchPage() {
   const playerSearchFieldId = 'playerSearch';
 
   function searchName() {
-    const playerName = (document.getElementById(playerSearchFieldId) as HTMLInputElement).value;
+    const playerName = (document.getElementById(playerSearchFieldId) as HTMLInputElement).value.replaceAll('#', '-');
     navigate(`/player/${encodeURIComponent(playerName)}`);
   }
   return (

--- a/front-end/src/styles/globals.css
+++ b/front-end/src/styles/globals.css
@@ -71,6 +71,10 @@ a {
   overflow: hidden;
 }
 
+.inline-flex {
+  display: inline-flex;
+}
+
 .hide-radio .MuiRadio-root {
   display: none !important;
 }


### PR DESCRIPTION
Now handles tag line serach. It uses the same format as opgg and league of graphs where the url is `name-tag`. 

![image](https://github.com/afieldi/RisenStats/assets/10212682/b9eeca2c-716c-4393-942a-9aa8033bbee0)

If you serach the user but they haven't been updated yet it looks like this:

![image](https://github.com/afieldi/RisenStats/assets/10212682/a7186d65-4c86-4623-8f3b-e683c822a51e)

hit the update button and the tagline will display. 