### PR TITLE
Add voidgrubs to the the database

### DIFF
--- a/BackEnd/src/business/timeline.ts
+++ b/BackEnd/src/business/timeline.ts
@@ -74,6 +74,7 @@ function DefaultTimelineStats(): TimelineParticipantStats {
     elderDragonKills: 0,
     riftHeraldKills: 0,
     baronKills: 0,
+    voidgrubKills: 0,
   } as TimelineParticipantStats;
 }
 
@@ -175,6 +176,10 @@ function HandleEliteMosterKill(allParticipants: TimelineParticipantStats[], even
 
   if(event.monsterType == MonsterType.RIFTHERALD) {
     allParticipants[id].riftHeraldKills += 1;
+  }
+
+  if (event.monsterType == MonsterType.HORDE) {
+    allParticipants[id].voidgrubKills += 1;
   }
 }
 

--- a/BackEnd/src/db/games.ts
+++ b/BackEnd/src/db/games.ts
@@ -144,6 +144,7 @@ export function CreateDbPlayerGameNoSave(riotPlayer: RiotParticipantDto, gameObj
     cloudDragonKills: timelineStats.cloudDragonKills,
     chemtechDragonKills: timelineStats.chemtechDragonKills,
     hextechDragonKills: timelineStats.hextechDragonKills,
+    voidgrubKills: timelineStats.voidgrubKills,
 
     items: [
       riotPlayer.item0,

--- a/Common/Interface/Database/timeline.ts
+++ b/Common/Interface/Database/timeline.ts
@@ -58,4 +58,5 @@ export interface TimelineParticipantStats
   elderDragonKills: number,
   baronKills: number,
   riftHeraldKills: number,
+  voidgrubKills: number
 }

--- a/Common/Interface/RiotAPI/RiotApiTimelineEvents.ts
+++ b/Common/Interface/RiotAPI/RiotApiTimelineEvents.ts
@@ -29,7 +29,8 @@ export enum MonsterSubType {
 export enum MonsterType {
   BARON_NASHOR ="BARON_NASHOR",
   RIFTHERALD = "RIFTHERALD",
-  DRAGON = "DRAGON"
+  DRAGON = "DRAGON",
+  HORDE = "HORDE" // voidgrubs are named horde
 }
 
 export interface RiotTimelineEvent

--- a/Common/models/playergame.model.ts
+++ b/Common/models/playergame.model.ts
@@ -239,6 +239,8 @@ export default class PlayerGameModel extends BaseEntity
   baronKills: number;
   @Column("smallint")
   riftHeraldKills: number;
+  @Column("smallint")
+  voidgrubKills: number;
 
   // Diff
   @Column("boolean")


### PR DESCRIPTION
Starts recording voidgrubs in the playergame model

### Notes
- Already added the field to the DB, backfilled it with 0
- Will deploy to prod once you approve

### Follow-ups
- Add a aggregated state field for player page
 
