### PR TITLE
Bugfixes april 2024

### DIFF
--- a/BackEnd/scripts/generateTeamModel.ts
+++ b/BackEnd/scripts/generateTeamModel.ts
@@ -5,8 +5,8 @@ import { ensureConnection, SaveObjects } from '../src/db/dbConnect';
 import PlayerTeamModel from '../../Common/models/playerteam.model';
 import { parse } from 'csv-parse/sync';
 import * as fs from 'fs';
-import { GetOrCreatePlayerOverviewByName } from '../src/business/player';
-import { buildRisenTeams } from '../src/business/teams';
+import { GetOrCreatePlayerOverviewByGameNameAndTagline } from '../src/business/player';
+import { splitNameTagLine } from '../../Common/utils';
 
 const path = require('path');
 
@@ -61,15 +61,16 @@ async function buildTeam(seasonId: number, displayName: string, abbreviation: st
   await SaveObjects(rows, TeamModel);
 }
 
-async function buildPlayersInTeams(seasonId: number, teamId: number, playersNames: string[]) {
+async function buildPlayersInTeams(seasonId: number, teamId: number, riotNames: string[]) {
   await ensureConnection();
 
   let playerPuuids: string[] = [];
 
-  for (let player of playersNames) {
+  for (let player of riotNames) {
     console.log(`Trying to load player ${player}`);
     try {
-      let playerModel = await GetOrCreatePlayerOverviewByName(player);
+      let riotAccountName = splitNameTagLine(player);
+      let playerModel = await GetOrCreatePlayerOverviewByGameNameAndTagline(riotAccountName[0], riotAccountName[1]);
       playerPuuids.push(playerModel.puuid);
     } catch (e) {
       console.log(`Couldnt Find [${player}] skipping`);
@@ -111,8 +112,8 @@ async function addLeague(seasonId: number, sheet: string) {
   // Add the players
   for (let row of rows) {
     let team = await findTeam(row.teamName, row.abrv, seasonId);
-    let playerNames = [row.top, row.jungle, row.mid, row.adc, row.support, row.sub1, row.sub2, row.sub3, row.sub4, row.sub5].filter(name => '' !== name);
-    await buildPlayersInTeams(seasonId, team.teamId, playerNames);
+    let riotNames = [row.top, row.jungle, row.mid, row.adc, row.support, row.sub1, row.sub2, row.sub3, row.sub4, row.sub5].filter(name => '' !== name);
+    await buildPlayersInTeams(seasonId, team.teamId, riotNames);
   }
 
   console.log('Finished Adding Players');

--- a/BackEnd/scripts/generateTeamModel.ts
+++ b/BackEnd/scripts/generateTeamModel.ts
@@ -61,12 +61,12 @@ async function buildTeam(seasonId: number, displayName: string, abbreviation: st
   await SaveObjects(rows, TeamModel);
 }
 
-async function buildPlayersInTeams(seasonId: number, teamId: number, riotNames: string[]) {
+async function buildPlayersInTeams(seasonId: number, teamId: number, nameWithTag: string[]) {
   await ensureConnection();
 
   let playerPuuids: string[] = [];
 
-  for (let player of riotNames) {
+  for (let player of nameWithTag) {
     console.log(`Trying to load player ${player}`);
     try {
       let riotAccountName = splitNameTagLine(player);

--- a/BackEnd/scripts/rebuildGameSummary.ts
+++ b/BackEnd/scripts/rebuildGameSummary.ts
@@ -1,0 +1,35 @@
+import dotenv from 'dotenv';
+dotenv.config({ path: '../.env.development' });
+import { CreatePlayerSummary, GetGameDataByMatchId, SaveDataByMatchId } from '../src/business/games';
+import GameModel from '../../Common/models/game.model';
+import { ensureConnection } from '../src/db/dbConnect';
+import { DOMINATE, DRAFT, MYTHICAL, RAMPAGE, UNSTOPPABLE } from './scriptConstants';
+
+
+async function rebuildGameSummary(seasonId: number) {
+  // let matchId = 'NA1_4955539419';
+  await ensureConnection();
+
+  let games = await GameModel.find({ where: { seasonId: seasonId } });
+  // let games = await GameModel.find({ where: { gameId: 4955539419 } });
+
+  let i = 0;
+  for (let game of games) {
+    console.log(`${i}/${games.length}`);
+    await rebuildPlayerSummary(game);
+    i++;
+  }
+
+
+}
+
+async function rebuildPlayerSummary(game: GameModel) {
+  await ensureConnection();
+  const gameData = await GetGameDataByMatchId(`NA1_${game.gameId}`);
+  game.playersSummary =  CreatePlayerSummary(gameData);
+  let savedGame = await game.save();
+  console.log(savedGame);
+}
+
+
+rebuildGameSummary(DRAFT);

--- a/BackEnd/scripts/scriptConstants.ts
+++ b/BackEnd/scripts/scriptConstants.ts
@@ -1,0 +1,6 @@
+// Used for per-season scripts, needs to be updated every season
+export const RAMPAGE: number = 30;
+export const UNSTOPPABLE: number = 31;
+export const DOMINATE: number = 32;
+export const DRAFT: number = 29;
+export const MYTHICAL: number = 28;

--- a/BackEnd/src/api/player.ts
+++ b/BackEnd/src/api/player.ts
@@ -1,7 +1,18 @@
 import express, { Request, Router } from 'express';
 import { TypedRequest, TypedResponse } from '../../../Common/Interface/Internal/responseUtil';
-import { PlayerGamesResponse, PlayerOverviewResponse, PlayerSeasonsResponse, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
-import { GetOrCreatePlayerOverviewByName, GetPlayerDetailedGames, GetPlayerSeasons, UpdateGamesByPlayerPuuid } from '../business/player';
+import {
+  PlayerGamesResponse,
+  PlayerOverviewRequest,
+  PlayerOverviewResponse,
+  PlayerSeasonsResponse,
+  UpdatePlayerGamesResponse
+} from '../../../Common/Interface/Internal/player';
+import {
+  GetOrCreatePlayerOverviewByGameNameAndTagline,
+  GetPlayerDetailedGames,
+  GetPlayerSeasons,
+  UpdateGamesByPlayerPuuid
+} from '../business/player';
 import logger from '../../logger';
 import { DocumentNotFound } from '../../../Common/errors';
 import { NonNone } from '../../../Common/utils';
@@ -28,11 +39,12 @@ router.post('/update/by-puuid/:playerPuuid', async(req: Request, res: TypedRespo
   }
 });
 
-router.post('/summary/by-name/:playerName', async(req: Request, res: TypedResponse<PlayerOverviewResponse>) => {
+router.post('/summary/by-name-and-tagline', async(req: TypedRequest<PlayerOverviewRequest>, res: TypedResponse<PlayerOverviewResponse>) => {
   try {
-    const playerNameWithTag = req.params.playerName;
-    logger.info(`Player summary by name ${playerNameWithTag}`);
-    const playerData = await GetOrCreatePlayerOverviewByName(playerNameWithTag);
+    const name = req.body.name;
+    const tagline = req.body.tagline;
+    logger.info(`Player summary by name: ${name} tageline: ${tagline}`);
+    const playerData = await GetOrCreatePlayerOverviewByGameNameAndTagline(name, tagline);
     res.json({
       overview: playerData
     });

--- a/BackEnd/src/business/games.ts
+++ b/BackEnd/src/business/games.ts
@@ -17,7 +17,7 @@ import { getDbPlayerTeamPlayerPuuid } from '../db/playerteam';
 import { buildRisenTeams } from './teams';
 import { GetDbActiveSeasonWithSheets } from '../db/season';
 
-async function GetGameDataByMatchId(matchId: string): Promise<RiotMatchDto> {
+export async function GetGameDataByMatchId(matchId: string): Promise<RiotMatchDto> {
   const gameData = await GetRiotGameByMatchId(matchId);
   if (gameData.info.participants.length !== 10) {
     throw new Error(`Invalid number of participants: ${gameData.info.participants.length}`);
@@ -118,14 +118,14 @@ export async function UpdatePlayersInSingleMatchById(gameObj: GameModel, gameDat
   return gameObj;
 }
 
-function CreatePlayerSummary(gameData: RiotMatchDto): GameSummaryPlayers {
+export function CreatePlayerSummary(gameData: RiotMatchDto): GameSummaryPlayers {
   const redPlayers: GameSummaryPlayer[] = [];
   const bluePlayers: GameSummaryPlayer[] = [];
   for (const participant of gameData.info.participants) {
     const player = {
       championId: participant.championId,
       team: participant.teamId,
-      playerName: participant.summonerName,
+      playerName: participant.riotIdGameName,
       tagline: participant.riotIdTagline,
       playerPuuid: participant.puuid,
       summoner1Id: participant.summoner1Id,
@@ -140,9 +140,9 @@ function CreatePlayerSummary(gameData: RiotMatchDto): GameSummaryPlayers {
       assists: participant.assists,
     } as GameSummaryPlayer;
     if (participant.teamId === 100) {
-      redPlayers.push(player);
-    } else {
       bluePlayers.push(player);
+    } else {
+      redPlayers.push(player);
     }
   }
   return {

--- a/BackEnd/src/business/games.ts
+++ b/BackEnd/src/business/games.ts
@@ -1,4 +1,4 @@
-import { CreateDbGame, CreateDbPlayerGameNoSave, GetDbGameByGameId, GetDbPlayerGamesByGameId } from '../db/games';
+import { CreateDbGame, CreateDbPlayerGameDatabaseObject, GetDbGameByGameId, GetDbPlayerGamesByGameId } from '../db/games';
 import { GameSummaryPlayer, GameSummaryPlayers, TeamSumStat, TeamSumStats } from '../../../Common/Interface/Database/game';
 import { RiotMatchDto, RiotParticipantDto } from '../../../Common/Interface/RiotAPI/RiotApiDto';
 import GameModel from '../../../Common/models/game.model';
@@ -78,7 +78,7 @@ export async function SaveSingleMatchById(matchId: string, gameData: RiotMatchDt
     const participant = gameData.info.participants[i];
     const teamStats = participant.teamId === 100 ? teamSumStats.blueStats : teamSumStats.redStats;
     const risenTeamId  = await getDbPlayerTeamPlayerPuuid(participant.puuid, seasonId);
-    objsToSave.push(CreateDbPlayerGameNoSave(participant, gameObj, timelineStats[i], teamStats, seasonId, i, risenTeamId));
+    objsToSave.push(CreateDbPlayerGameDatabaseObject(participant, gameObj, timelineStats[i], teamStats, seasonId, i, risenTeamId));
   }
   await SaveObjects(objsToSave);
   return gameObj;
@@ -112,7 +112,7 @@ export async function UpdatePlayersInSingleMatchById(gameObj: GameModel, gameDat
     const risenTeamId  = await getDbPlayerTeamPlayerPuuid(participant.puuid, seasonId);
 
     const teamStats = participant.teamId === 100 ? teamSumStats.blueStats : teamSumStats.redStats;
-    objsToSave.push(CreateDbPlayerGameNoSave(participant, gameObj, timelineStats[i], teamStats, seasonId, i, risenTeamId));
+    objsToSave.push(CreateDbPlayerGameDatabaseObject(participant, gameObj, timelineStats[i], teamStats, seasonId, i, risenTeamId));
   }
   await SaveObjects(objsToSave);
   return gameObj;

--- a/BackEnd/src/business/player.ts
+++ b/BackEnd/src/business/player.ts
@@ -15,30 +15,6 @@ import logger from '../../logger';
 import { GetDbGamesByGameIds, GetDbPlayerGamesByPlayerPuuid } from '../db/games';
 import { ApiError } from '../external-api/_call';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
-import { splitNameTagLine } from '../../../Common/utils';
-
-export async function GetOrCreatePlayerOverviewByName(playerName: string): Promise<PlayerModel> {
-  try {
-    const [name, tagline] = splitNameTagLine(playerName); 
-    const riotPlayer = await GetRiotPlayerByGameNameAndTagline(name, tagline ?? 'NA1');
-    if (!riotPlayer) {
-      throw new DocumentNotFound(`Player with name ${playerName} not found`);
-    }
-    try {
-      return await GetDbPlayerByPuuid(riotPlayer.puuid);
-    } catch (error) {}
-
-    const riotLeague = await GetRiotLeagueBySummonerId(riotPlayer.id);
-    return await CreateDbPlayerWithRiotPlayer(riotPlayer, riotLeague);
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (error.status === 404) {
-        throw new DocumentNotFound(`Player with name ${playerName} not found`);
-      }
-    }
-    throw error;
-  }
-}
 
 export async function GetOrCreatePlayerOverviewByGameNameAndTagline(gameName: string, tagline: string): Promise<PlayerModel> {
   try {

--- a/BackEnd/src/db/games.ts
+++ b/BackEnd/src/db/games.ts
@@ -19,16 +19,9 @@ const roleOrder = [
   GameRoles.SUPPORT
 ];
 
-export function CreateDbPlayerGameNoSave(riotPlayer: RiotParticipantDto, gameObj: GameModel,
+export function CreateDbPlayerGameDatabaseObject(riotPlayer: RiotParticipantDto, gameObj: GameModel,
   timelineStats: TimelineParticipantStats, teamStats: TeamSumStat, seasonId: number, lobbyOrder: number, teamId?: number): PlayerGameModel {
-
-  if (!riotPlayer.challenges) {
-    const d = new Date(0);
-    d.setUTCMilliseconds(gameObj.gameStart);
-    logger.warn(`Game ${gameObj.gameId} has no challenge stats. Probably too old. Game start: ${d.toUTCString()}`);
-  }
-
-
+  
   const shortPlayerData = {
     game: gameObj,
     timestamp: gameObj.gameStart,

--- a/Common/Interface/Internal/player.ts
+++ b/Common/Interface/Internal/player.ts
@@ -2,6 +2,10 @@ import PlayerGameModel from "../../models/playergame.model";
 import PlayerModel from "../../models/player.model";
 import GameModel from "../../models/game.model";
 
+export interface PlayerOverviewRequest {
+  name: string,
+  tagline: string
+}
 export interface PlayerOverviewResponse {
   overview: PlayerModel
 }

--- a/Common/Interface/RiotAPI/RiotApiDto.ts
+++ b/Common/Interface/RiotAPI/RiotApiDto.ts
@@ -361,7 +361,7 @@ export interface RiotParticipantDto
   profileIcon: number;
   puuid: string;
   quadraKills: number;
-  riotIdName: string;
+  riotIdGameName: string;
   riotIdTagline: string;
   role: string;
   sightWardsBoughtInGame: number;

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -31,7 +31,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Home />}></Route>
             <Route path="/search" element={<SearchPage />}></Route>
-            <Route path="/player/:playerName" element={<Player />}></Route>
+            <Route path="/player/:playerNameWithTagline" element={<Player />}></Route>
             <Route path="/leagues/:leagueName" element={<LeaguePage />}></Route>
             <Route path="/leaderboard" element={<Leaderboards />}></Route>
             <Route path="/leagues/:leagueName/:teamName" element={<TeamPage />}></Route>

--- a/front-end/src/api/player.ts
+++ b/front-end/src/api/player.ts
@@ -1,11 +1,27 @@
-import { PlayerGamesResponse, PlayerOverviewResponse, PlayerSeasonsResponse, UpdatePlayerGamesResponse } from '../../../Common/Interface/Internal/player';
+import {
+  PlayerGamesResponse,
+  PlayerOverviewRequest,
+  PlayerOverviewResponse,
+  PlayerSeasonsResponse,
+  UpdatePlayerGamesResponse
+} from '../../../Common/Interface/Internal/player';
 import { GetGamesRequest, GetGamesResponse } from '../../../Common/Interface/Internal/games';
 import { MakeBackendCall } from './_call';
 import { GetPlayerStatsByDateAndSeasonRequest, GetPlayerStatsByDateAndSeasonResponse, GetPlayerStatsRequest, GetPlayerStatsResponse } from '../../../Common/Interface/Internal/playerstats';
 import { DEFAULT_RISEN_SEASON_ID } from '../../../Common/constants';
+import { splitNameTagLine } from '../../../Common/utils';
 
-export async function GetPlayerProfile(playerName: string): Promise<PlayerOverviewResponse> {
-  return await MakeBackendCall(`/api/player/summary/by-name/${playerName}`, 'POST', {}) as PlayerOverviewResponse;
+export async function GetPlayerProfileByPlayerNameAndTagline(playerNameAndTagline: string) {
+  let nameAndTagline = splitNameTagLine(playerNameAndTagline);
+  return GetPlayerProfile(nameAndTagline[0], nameAndTagline[1]);
+}
+
+export async function GetPlayerProfile(name: string, tagline: string): Promise<PlayerOverviewResponse> {
+  const params: PlayerOverviewRequest = {
+    tagline,
+    name,
+  };
+  return await MakeBackendCall('/api/player/summary/by-name-and-tagline', 'POST', params) as PlayerOverviewResponse;
 }
 
 export async function GetPlayerGames(playerPuuid: string, seasonId: string): Promise<GetGamesResponse> {

--- a/front-end/src/common/utils.ts
+++ b/front-end/src/common/utils.ts
@@ -139,3 +139,7 @@ export function getTeamStats(gameModel: GameModel): RedAndBlueStats {
     },
   };
 }
+
+export function getEncodedNameWithTagline(name: string, tagline: string): string {
+  return `${encodeURIComponent(name)}-${encodeURIComponent(tagline)}`;
+}

--- a/front-end/src/components/player-page/game-summary/team-info.tsx
+++ b/front-end/src/components/player-page/game-summary/team-info.tsx
@@ -25,7 +25,6 @@ const flexDirectionByTeamColor: Record<TeamColor, string> = {
 };
 
 function TeamInfo(teamInfoProps: TeamInfoProps) {
-
   const alignment: 'left' | 'right' = alignmentByTeamColor[teamInfoProps.teamColor];
   const rowType = flexDirectionByTeamColor[teamInfoProps.teamColor];
   return <Box sx={{ display: 'flex', flexDirection: 'column', width: '50%', pr: .5 }}>
@@ -47,7 +46,7 @@ function TeamInfo(teamInfoProps: TeamInfoProps) {
                 width="15px"/>
             </Box>
             <Box sx={{ overflow: 'hidden' }}>
-              <Link to={`/player/${encodeURIComponent(player.playerName)}`}>
+              <Link to={`/player/${encodeURIComponent(player.playerName)}-${encodeURIComponent(player.tagline)}`}>
                 <Typography variant="body2" align={alignment} className="clickable-bg no-overflow player-names">
                   {player.playerName}
                 </Typography>

--- a/front-end/src/components/player-page/game-summary/team-info.tsx
+++ b/front-end/src/components/player-page/game-summary/team-info.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from '@mui/material';
 import React from 'react';
 import { GameSummaryPlayer } from '../../../../../Common/Interface/Database/game';
 import { Link } from 'react-router-dom';
+import { getEncodedNameWithTagline } from '../../../common/utils';
 
 export enum TeamColor {
     BLUE = 'blue',
@@ -46,7 +47,7 @@ function TeamInfo(teamInfoProps: TeamInfoProps) {
                 width="15px"/>
             </Box>
             <Box sx={{ overflow: 'hidden' }}>
-              <Link to={`/player/${encodeURIComponent(player.playerName)}-${encodeURIComponent(player.tagline)}`}>
+              <Link to={`/player/${getEncodedNameWithTagline(player.playerName, player.tagline)}`}>
                 <Typography variant="body2" align={alignment} className="clickable-bg no-overflow player-names">
                   {player.playerName}
                 </Typography>

--- a/front-end/src/pages/player/player.tsx
+++ b/front-end/src/pages/player/player.tsx
@@ -6,7 +6,11 @@ import { tabLabelProps, TabPanel } from '../../components/tab-panel/tab-panel';
 import PlayerPageGeneral from '../../components/player-page/general';
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { GetDetailedPlayerGames, GetPlayerProfile, GetPlayerStats } from '../../api/player';
+import {
+  GetDetailedPlayerGames,
+  GetPlayerProfileByPlayerNameAndTagline,
+  GetPlayerStats
+} from '../../api/player';
 import { PlayerDetailedGame, PlayerOverviewResponse } from '../../../../Common/Interface/Internal/player';
 
 import '../../styles/player.css';
@@ -22,7 +26,7 @@ import { DEFAULT_RISEN_SEASON_ID } from '../../../../Common/constants';
 
 function PlayerPage()
 {
-  let { playerName } = useParams();
+  let { playerNameWithTagline } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -39,9 +43,9 @@ function PlayerPage()
   const [roleId, setRoleId] = useState<GameRoles>(GameRoles.ALL);
 
   async function loadPlayerProfile() {
-    if (playerName) {
+    if (playerNameWithTagline) {
       try {
-        const profile = await GetPlayerProfile(playerName);
+        const profile = await GetPlayerProfileByPlayerNameAndTagline(playerNameWithTagline);
         setPlayerProfile(profile);
         return profile;
       }


### PR DESCRIPTION
## Bugfixes:
- Fix riotDTO having wrong field names 
- fix the team arrays being swapped (100 is blue)
- Fix the teams card not redirecting to the page (was using the old convention)
- Fix tagline not being assigned correctly for the gamesummary (maybe, will need to validate whenever another risen series is played), For now ive backfilled using the `rebuildGameSummary.ts` script. That script just calls the same function that the other ones so it should work now.

## Changes:
- Deprecate a (by-name) API, since riot is not supporting by summoner name this is being renamed to more accurately repersent the state of the world. (Updates both frontend and backend)
- Rename some state names in the front end to accurately repersent the state of the world.