### PR TITLE
Qol may

### DIFF
--- a/BackEnd/src/api/leaderboards.ts
+++ b/BackEnd/src/api/leaderboards.ts
@@ -3,8 +3,8 @@ import { TypedRequest, TypedResponse } from '../../../Common/Interface/Internal/
 import logger from '../../logger';
 import { GameRoles } from '../../../Common/Interface/General/gameEnums';
 import { GetLeaderboardRequest, GetLeaderboardResponse } from '../../../Common/Interface/Internal/leaderboard';
-import { GetDbLeaderboardsBySeasonIdAndRole } from '../db/leaderboards';
 import AggregatedPlayerStatModel from '../../../Common/models/aggregatedplayerstat.model';
+import { GetLeaderboardsBySeasonIdAndRole } from '../business/leaderboards';
 
 const router: Router = express.Router();
 
@@ -18,7 +18,7 @@ router.post('/', async(req: TypedRequest<GetLeaderboardRequest>, res: TypedRespo
       res.status(403).send(`SeasonId or RoleId not provided! SeasonId: ${seasonId} ${roleId}`);
     }
 
-    const playerStats: AggregatedPlayerStatModel[] = await GetDbLeaderboardsBySeasonIdAndRole(seasonId, roleId);
+    const playerStats: AggregatedPlayerStatModel[] = await GetLeaderboardsBySeasonIdAndRole(seasonId, roleId);
     res.json({
       playerStats
     });

--- a/BackEnd/src/business/leaderboards.ts
+++ b/BackEnd/src/business/leaderboards.ts
@@ -1,0 +1,19 @@
+import { GameRoles } from '../../../Common/Interface/General/gameEnums';
+import AggregatedPlayerStatModel from '../../../Common/models/aggregatedplayerstat.model';
+import { GetDbLeaderboardsBySeasonIdAndRole } from '../db/leaderboards';
+
+const BASE_MIN_NUMBER_OF_GAMES = 4;
+
+export async function GetLeaderboardsBySeasonIdAndRole(seasonId: number, roleId: GameRoles): Promise<AggregatedPlayerStatModel[]> {
+  let flattenedLeaderboard = await GetDbLeaderboardsBySeasonIdAndRole(seasonId, roleId);
+
+  let minGames = BASE_MIN_NUMBER_OF_GAMES;
+
+  // Early in the season there will always be not enough games to satisfy the min count, so in this case we use the average so the early weeks have leaderboards.
+  let averageGames = Math.round(flattenedLeaderboard.reduce((sum, player) => sum + player.games, 0) / flattenedLeaderboard.length);
+  if (averageGames < BASE_MIN_NUMBER_OF_GAMES) {
+    minGames = averageGames;
+  }
+
+  return flattenedLeaderboard.filter(playerStatModel => playerStatModel.games >= minGames);
+}

--- a/BackEnd/src/db/leaderboards.ts
+++ b/BackEnd/src/db/leaderboards.ts
@@ -5,7 +5,6 @@ import { combine } from '../../../Common/utils';
 import AggregatedPlayerStatModel from '../../../Common/models/aggregatedplayerstat.model';
 import logger from '../../logger';
 
-const minNumberOfGames = 4;
 
 // TODO for later:
 // Make a selector in the LB page for season/role
@@ -31,8 +30,7 @@ export async function GetDbLeaderboardsBySeasonIdAndRole(seasonId: number, roleI
   // If the role is ALL combine the data into one object and return it.
   let flattenedLeaderboard = flattenLeaderboard(leaderboard);
   logger.info(flattenedLeaderboard.length);
-  // Filter out players without the required amount of games
-  return flattenedLeaderboard.filter(playerStatModel => playerStatModel.games >= minNumberOfGames);
+  return flattenedLeaderboard;
 }
 
 function flattenLeaderboard(playerStatsModel: AggregatedPlayerStatModel[]) {

--- a/front-end/src/components/league-page/team-leaderboards.tsx
+++ b/front-end/src/components/league-page/team-leaderboards.tsx
@@ -30,8 +30,10 @@ interface LeaderboardStats {
   totalGameLength: number;
   totalGamesByTeam: number;
   totalDragonsByTeam: number;
-  baronKillsByTeam: number;
-  riftHeraldKillsByTeam: number;
+  totalBaronKillsByTeam: number;
+  totalRiftHeraldKillsByTeam: number;
+  totalVoidGrubsKillsByTeam: number;
+  totalTurretPlatesByTeam: number;
   goldDiff15ByTeam: number;
   csDiff15ByTeam: number;
 }
@@ -145,29 +147,56 @@ export function getLeaderboardCardProps(leaderboardStats: Map<number, Leaderboar
 
   // Average Rift
   const sortedEntriesRiftHerald = [...leaderboardStats.entries()]
-    .sort((a, b) => ((b[1].riftHeraldKillsByTeam/b[1].totalGamesByTeam) - (a[1].riftHeraldKillsByTeam/a[1].totalGamesByTeam)))
+    .sort((a, b) => ((b[1].totalRiftHeraldKillsByTeam/b[1].totalGamesByTeam) - (a[1].totalRiftHeraldKillsByTeam/a[1].totalGamesByTeam)))
     .slice(0, howManyToDisplay);
 
   leaderboardCardProps.set('Rift Heralds', {
     titleOfCard: 'Average Rift Heralds',
     lbColumnTitle: 'Herald',
     orderedleaderboard: new Map(sortedEntriesRiftHerald),
-    mainValueCalculator: (leaderboardStat: LeaderboardStats) => roundTo((leaderboardStat.riftHeraldKillsByTeam / leaderboardStat.totalGamesByTeam) * 5), // Multiply to 5 to account for 5 players
+    mainValueCalculator: (leaderboardStat: LeaderboardStats) => roundTo((leaderboardStat.totalRiftHeraldKillsByTeam / leaderboardStat.totalGamesByTeam) * 5), // Multiply to 5 to account for 5 players
     formatter: (v: number) => `${v}`
   });
 
   // Average Rift
   const sortedEntriesBarons = [...leaderboardStats.entries()]
-    .sort((a, b) => ((b[1].baronKillsByTeam/b[1].totalGamesByTeam) - (a[1].baronKillsByTeam/a[1].totalGamesByTeam)))
+    .sort((a, b) => ((b[1].totalBaronKillsByTeam/b[1].totalGamesByTeam) - (a[1].totalBaronKillsByTeam/a[1].totalGamesByTeam)))
     .slice(0, howManyToDisplay);
 
   leaderboardCardProps.set('Barons', {
     titleOfCard: 'Average Barons',
     lbColumnTitle: 'Barons',
     orderedleaderboard: new Map(sortedEntriesBarons),
-    mainValueCalculator: (leaderboardStat: LeaderboardStats) => roundTo((leaderboardStat.baronKillsByTeam / leaderboardStat.totalGamesByTeam) * 5), // Multiply to 5 to account for 5 players
+    mainValueCalculator: (leaderboardStat: LeaderboardStats) => roundTo((leaderboardStat.totalBaronKillsByTeam / leaderboardStat.totalGamesByTeam) * 5), // Multiply to 5 to account for 5 players
     formatter: (v: number) => `${v}`
   });
+
+  // Average Void Grubs
+  const sortedEntriesVoidGrubs = [...leaderboardStats.entries()]
+    .sort((a, b) => ((b[1].totalVoidGrubsKillsByTeam/b[1].totalGamesByTeam) - (a[1].totalVoidGrubsKillsByTeam/a[1].totalGamesByTeam)))
+    .slice(0, howManyToDisplay);
+
+  leaderboardCardProps.set('Void Grubs', {
+    titleOfCard: 'Average Void Grubs',
+    lbColumnTitle: 'Grubs',
+    orderedleaderboard: new Map(sortedEntriesVoidGrubs),
+    mainValueCalculator: (leaderboardStat: LeaderboardStats) => roundTo((leaderboardStat.totalVoidGrubsKillsByTeam / leaderboardStat.totalGamesByTeam) * 5), // Multiply to 5 to account for 5 players
+    formatter: (v: number) => `${v}`
+  });
+
+  // Average Turret Plates
+  const sortedEntriesTurretPlates = [...leaderboardStats.entries()]
+    .sort((a, b) => ((b[1].totalTurretPlatesByTeam/b[1].totalGamesByTeam) - (a[1].totalTurretPlatesByTeam/a[1].totalGamesByTeam)))
+    .slice(0, howManyToDisplay);
+
+  leaderboardCardProps.set('Turret Plates', {
+    titleOfCard: 'Average Turret Plates',
+    lbColumnTitle: 'Plates',
+    orderedleaderboard: new Map(sortedEntriesTurretPlates),
+    mainValueCalculator: (leaderboardStat: LeaderboardStats) => roundTo((leaderboardStat.totalTurretPlatesByTeam / leaderboardStat.totalGamesByTeam) * 5), // Multiply to 5 to account for 5 players
+    formatter: (v: number) => `${v}`
+  });
+
 
   return leaderboardCardProps;
 }
@@ -182,10 +211,12 @@ function buildLeaderboardStats(games: PlayerGameModel[]): Map<number, Leaderboar
         totalGameLength: 0,
         totalGamesByTeam: 0,
         totalDragonsByTeam: 0,
-        baronKillsByTeam: 0,
-        riftHeraldKillsByTeam: 0,
+        totalBaronKillsByTeam: 0,
+        totalRiftHeraldKillsByTeam: 0,
         goldDiff15ByTeam: 0,
         csDiff15ByTeam: 0,
+        totalVoidGrubsKillsByTeam: 0,
+        totalTurretPlatesByTeam: 0,
       };
 
       const updatedStats: LeaderboardStats = {
@@ -200,10 +231,12 @@ function buildLeaderboardStats(games: PlayerGameModel[]): Map<number, Leaderboar
             game.hextechDragonKills +
             game.chemtechDragonKills +
             game.elderDragonKills,
-        baronKillsByTeam: existingStats.baronKillsByTeam + game.baronKills,
-        riftHeraldKillsByTeam: existingStats.riftHeraldKillsByTeam + game.riftHeraldKills,
+        totalBaronKillsByTeam: existingStats.totalBaronKillsByTeam + game.baronKills,
+        totalRiftHeraldKillsByTeam: existingStats.totalRiftHeraldKillsByTeam + game.riftHeraldKills,
         goldDiff15ByTeam: existingStats.goldDiff15ByTeam + game.goldDiff15,
         csDiff15ByTeam: existingStats.csDiff15ByTeam + game.csDiff15,
+        totalVoidGrubsKillsByTeam: existingStats.totalVoidGrubsKillsByTeam + game.voidgrubKills,
+        totalTurretPlatesByTeam: existingStats.totalTurretPlatesByTeam + game.turretPlatesTaken
       };
       leaderboardStatsMap.set(risenTeamTeamId, updatedStats);
     }

--- a/front-end/src/components/tables/player-tier.tsx
+++ b/front-end/src/components/tables/player-tier.tsx
@@ -47,6 +47,8 @@ function MapStatsToLeaderboard(data: AggregatedPlayerStatModel[]): LeaderboardTy
   }));
 }
 
+const defaultSortedBy = 'tier';
+
 export default function PlayerTierTable(props: PlayerTierTableProps) {
   const {
     seasonId,
@@ -58,7 +60,7 @@ export default function PlayerTierTable(props: PlayerTierTableProps) {
 
   const [playersStats, setPlayersStats] = useState<LeaderboardType[]>([]);
   const [loadingStats, setLoadingStats] = useState<boolean>(false);
-  const [sortCol, setSortCol] = useState<keyof LeaderboardType>('playerName');
+  const [sortCol, setSortCol] = useState<keyof LeaderboardType>(defaultSortedBy);
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.DESC);
 
   useEffect(() => {


### PR DESCRIPTION
## Changes
- Sorts the leaderboards by tier by default (pretty requested feature)
- if the average number of games in the league is less than 4 then we just use the average game count as the base. (helps out for week 1/2 where we didn't display leaderboards without having low game count players later in the season).
- Adds team leaderboards for voidgrubs and turret plates.

## Followups
- Please deploy frontend once this is merged. I will deploy backend