### PR TITLE
Fix bounties type since they can be decimals now

### DIFF
--- a/Common/models/playergame.model.ts
+++ b/Common/models/playergame.model.ts
@@ -421,7 +421,7 @@ export default class PlayerGameModel extends BaseEntity
   @Column("smallint")
   blastConeOppositeOpponentCount: number;
 
-  @Column("smallint")
+  @Column("real", {nullable: true})
   bountyGold: number;
 
   @Column("smallint")


### PR DESCRIPTION
in the latest patch bounties can now be decimals so we need to update this. Its nullable because we apparently have some null fields and im too lazy to backfil