### PR TITLE
Update script for elo stocks to do entire elo timeline in memory, fix…

### DIFF
--- a/BackEnd/scripts/testRisenStocks.ts
+++ b/BackEnd/scripts/testRisenStocks.ts
@@ -1,47 +1,105 @@
 import dotenv from 'dotenv';
 dotenv.config({ path: '../.env.development' });
 
-import { getStockTimelinesForSeason, updateStocksValueAfterMatch, updateTeamStocksForGame } from '../src/business/stocks';
+import {
+  calculateNewDollarValue,
+  createBaselineForTeam,
+  getRisenTeamsFromMatch,
+  getStockTimelinesForSeason,
+  updateStocksValueAfterMatch,
+  updateTeamStocksForGame
+} from '../src/business/stocks';
 import { CHAMPIONS, DOMINATE, DRAFT, MYTHICAL, RAMPAGE, UNSTOPPABLE } from './scriptConstants';
-import { deleteDbStockTimeLineForSeason } from '../src/db/stocks';
-import { GetDbPlayerGames } from '../src/db/games';
+import { deleteDbStockTimeLineForSeason, getDbLatestStockValue } from '../src/db/stocks';
+import { GetDbPlayerGames, GetDbPlayerGamesByGameId } from '../src/db/games';
+import PlayerGameModel from '../../Common/models/playergame.model';
+import { ToGameId } from '../../Common/utils';
+import StockTimelineModel from '../../Common/models/stocktimeline.model';
+import { GetDbActiveSeasonWithSheets } from '../src/db/season';
+import { GetDbTeamsByTeamId } from '../src/db/teams';
+import { SaveObjects } from '../src/db/dbConnect';
+import TeamModel from '../../Common/models/team.model';
 
 // In the case that callback doesnt work, rebuild the stocktimeline from scratch
 // Assumes all games are in the league
 // We can do this because the stock value SHOULD be deterministic
 async function rebuildStocktimelineForLeague(seasonId: number) {
-  // await deleteDbStockTimeLineForSeason(seasonId);
+  await deleteDbStockTimeLineForSeason(seasonId);
   let games = await GetDbPlayerGames({ seasonId: seasonId });
   let gameIds = new Set<number>();
   for (let game of games) {
     gameIds.add(game.gameGameId);
   }
 
-  console.log(gameIds);
+  let fullGames: PlayerGameModel[] =  [];
 
+  // Ensure the games are in order
   for (let gameId of gameIds) {
-    await updateTeamStocksForGame(`NA1_${gameId}`);
+    let matchId = `NA1_${gameId}`;
+    const allPlayersGames: PlayerGameModel[] = await GetDbPlayerGamesByGameId(ToGameId(matchId));
+    fullGames.push(allPlayersGames[0]);
   }
+
+  fullGames.sort((a, b) => a.timestamp - b.timestamp);
+  const sortedGameIds = fullGames.map(game => game.gameGameId);
+
+  await batchUpdateStocks(sortedGameIds);
 }
 
-async function testRisenStocks() {
+// For this script we need to do this all in memory cause there some race conditions
+async function batchUpdateStocks(sortedGameIds: number[]) {
+  let timelines: Map<number, StockTimelineModel[]> = new Map();
+  for (let gameId of sortedGameIds) {
+    let matchId =  `NA1_${gameId}`;
 
-  // let baseTime = Date.now();
-  // let weeks = 1;
-  // let i = 0;
-  // let sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
-  // for (let result of match_history) {
-  //   let t: Date = new Date(baseTime + (weeks * sevenDaysInMilliseconds));
-  //   if( i % 8 == 0) {
-  //     weeks++;
-  //   }
-  //   await updateStocksValueAfterMatch(DOMINATE, result.winning,result.losing, t);
-  //   i++;
-  // }
-  // await updateTeamStocksForGame('NA_5118392706'); // Dominate KFC
-  // await updateTeamStocksForGame('NA1_5126746617'); // DRAFT
-  let x = await getStockTimelinesForSeason(DOMINATE);
-  console.log(x);
+    console.log(matchId);
+
+    let matchInfo  = await getRisenTeamsFromMatch(matchId);
+    let seasonModel = await GetDbActiveSeasonWithSheets(matchInfo.risenSeasonid);
+    let winningTeamModel  = await GetDbTeamsByTeamId(matchInfo.winningTeamId, matchInfo.risenSeasonid);
+    let losingTeamModel   = await GetDbTeamsByTeamId(matchInfo.losingTeamId, matchInfo.risenSeasonid);
+
+    if(timelines.get(matchInfo.winningTeamId) == null) {
+      timelines.set(matchInfo.winningTeamId, [ ]);
+    }
+
+    if(timelines.get(matchInfo.losingTeamId) == null) {
+      timelines.set(matchInfo.losingTeamId, [ ]);
+    }
+
+    let winningTimeline = timelines.get(matchInfo.winningTeamId);
+    let losingTimeline = timelines.get(matchInfo.losingTeamId);
+    let winnerCurrentStockValue = winningTimeline.length == 0 ? await createBaselineForTeam(matchInfo.risenSeasonid, matchInfo.winningTeamId) : winningTimeline[winningTimeline.length - 1].dollarValue;
+    let loserCurrentStockValue = losingTimeline.length == 0 ? await createBaselineForTeam(matchInfo.risenSeasonid, matchInfo.losingTeamId) : losingTimeline[losingTimeline.length - 1].dollarValue;
+
+    // Calculate new value of teams
+    let updatedStockValues = calculateNewDollarValue(winnerCurrentStockValue, loserCurrentStockValue);
+
+    console.log(`[${matchInfo.winningTeamId}]: ${winnerCurrentStockValue} -> ${updatedStockValues.newWinnerDollarValue}`);
+    console.log(`[${matchInfo.losingTeamId}]: ${loserCurrentStockValue} -> ${updatedStockValues.newLoserDollarValue}`);
+
+    let winningStock = StockTimelineModel.create({
+      transactionId: 0,
+      teamSeason: seasonModel,
+      team: winningTeamModel,
+      dollarValue: updatedStockValues.newWinnerDollarValue,
+      timestamp: matchInfo.matchTimestamp
+    });
+
+    let losingStock = StockTimelineModel.create({
+      transactionId: 0,
+      teamSeason: seasonModel,
+      team: losingTeamModel,
+      dollarValue: updatedStockValues.newLoserDollarValue,
+      timestamp: matchInfo.matchTimestamp
+    });
+
+    timelines.get(matchInfo.winningTeamId).push(winningStock);
+    timelines.get(matchInfo.losingTeamId).push(losingStock);
+  }
+
+  const rows: StockTimelineModel[] = Array.from(timelines.values()).flat();
+  await SaveObjects(rows, StockTimelineModel);
 }
 
 rebuildStocktimelineForLeague(DRAFT);

--- a/BackEnd/src/db/stocks.ts
+++ b/BackEnd/src/db/stocks.ts
@@ -14,7 +14,7 @@ export async function getDbLatestStockValue(seasonId: number, teamId: number): P
 
   const searchFilter: FindOneOptions<StockTimelineModel> =  {
     where: { teamTeamId: teamId, teamSeasonId: seasonId },
-    order: { timestamp: 'DESC' }, // Order by timestamp in descending order
+    order: { timestamp: 'ASC' }, // Order by timestamp in descending order
   };
   return await StockTimelineModel.findOne(searchFilter);
 }


### PR DESCRIPTION
- Talked with people in risen, people like a flat elo calue better than using the team based
- Fixed a bug which was causing the elo to be calcualted using the oldest value instead of the latest
- Update the script for rebuilding the elo to be run completely in memory cause i was getting some weird behaviour when fetching from the DB in quick successions.