### PR TITLE
Add api to to update sheetId

### DIFF
--- a/BackEnd/src/api/season.ts
+++ b/BackEnd/src/api/season.ts
@@ -4,19 +4,45 @@ import {
   CreateSeasonRequest,
   GetSeasonRequest,
   GetSeasonResponse,
-  GetSeasonsResponse
+  GetSeasonsResponse,
+  UpdateSeasonGoogleSheetIdRequest,
+  UpdateSeasonGoogleSheetIdResponse
 } from '../../../Common/Interface/Internal/season';
 import {
   CreateSeason,
   GetSeasonBySearchName,
   GetSeasons,
-  GetActiveSeasonThatPlayerHasParticiaptedInByPuuid
+  GetActiveSeasonThatPlayerHasParticiaptedInByPuuid,
+  UpdateSeasonGoogleSheetId
 } from '../business/season';
 import logger from '../../logger';
 import { number } from 'yargs';
 import { GetPlayerStatsRequest } from '../../../Common/Interface/Internal/playerstats';
+import { DocumentNotFound, InvalidRequestError } from '../../../Common/errors';
 
 const router: Router = express.Router();
+
+router.post('/update/google-sheet-id', async(req: TypedRequest<UpdateSeasonGoogleSheetIdRequest>, res: TypedResponse<UpdateSeasonGoogleSheetIdResponse>) => {
+  logger.debug(`Season update google sheet id ${JSON.stringify(req.body)}`);
+
+  try {
+    const { seasonId } = req.body;
+    const googleSheetId = req.body.googleSheetId?.trim();
+    await UpdateSeasonGoogleSheetId(seasonId, googleSheetId);
+    res.json({
+      success: true
+    });
+  } catch (error) {
+    logger.error(error);
+    if (error instanceof InvalidRequestError) {
+      res.status(400).send(error.message);
+    } else if (error instanceof DocumentNotFound) {
+      res.status(404).send(error.message);
+    } else {
+      res.status(500).send('Something went wrong');
+    }
+  }
+});
 
 router.post('/get/all', async(req: Request, res: TypedResponse<GetSeasonsResponse>) => {
   logger.debug('Season get all');

--- a/BackEnd/src/api/teams.ts
+++ b/BackEnd/src/api/teams.ts
@@ -2,14 +2,43 @@ import express, { Router } from 'express';
 import { TypedRequest, TypedResponse } from '../../../Common/Interface/Internal/responseUtil';
 import logger from '../../logger';
 import {
+  BuildRisenTeamsRequest,
+  BuildRisenTeamsResponse,
   GetTeamAbbreviationResponse,
   GetTeamByAbbreviationRequest, GetTeamRosterRequest, GetTeamRosterResponse,
   GetTeamsRequest,
   GetTeamsResponse
 } from '../../../Common/Interface/Internal/teams';
-import { GetTeamRosterByTeamIdAndSeason, GetTeamsBySeasonId, GetTeamsByTeamAbbreviation } from '../business/teams';
+import {
+  buildRisenTeams,
+  GetTeamRosterByTeamIdAndSeason,
+  GetTeamsBySeasonId,
+  GetTeamsByTeamAbbreviation
+} from '../business/teams';
+import { InvalidRequestError } from '../../../Common/errors';
 
 const router: Router = express.Router();
+
+router.post('/build', async(req: TypedRequest<BuildRisenTeamsRequest>, res: TypedResponse<BuildRisenTeamsResponse>) => {
+  try {
+    const seasonId = Number(req.body.seasonId);
+    if (isNaN(seasonId)) {
+      throw new InvalidRequestError('Invalid seasonId');
+    }
+    logger.info(`Building teams for seasonId: ${seasonId}`);
+    await buildRisenTeams(seasonId);
+    res.json({
+      success: true
+    });
+  } catch (error) {
+    logger.error(error);
+    if (error instanceof InvalidRequestError) {
+      res.status(400).send(error.message);
+    } else {
+      res.status(500).send(error.message || 'Something went wrong');
+    }
+  }
+});
 
 router.post('/by-seasonId/:seasonId', async(req: TypedRequest<GetTeamsRequest>, res: TypedResponse<GetTeamsResponse>) => {
   try {

--- a/BackEnd/src/business/games.ts
+++ b/BackEnd/src/business/games.ts
@@ -57,7 +57,11 @@ export async function SaveDataByMatchId(matchId: string): Promise<GameModel> {
 
   let recentlyBuiltRisenTeams = await hasRecentlyBuiltRisenTeams(seasonId);
   if (seasonId && !recentlyBuiltRisenTeams) {
-    await buildRisenTeams(seasonId);
+    try {
+      await buildRisenTeams(seasonId);
+    } catch (error) {
+      logger.error(`Failed to build risen teams for season ${seasonId}: ${error.message}`);
+    }
   }
 
   return await SaveSingleMatchById(matchId, gameData, seasonId);
@@ -218,7 +222,11 @@ async function saveMatchForGameAlreadyInDb(matchId: string) {
   // If its a game for a risen season then update the teams.
   let recentlyBuiltRisenTeams = await hasRecentlyBuiltRisenTeams(existingObj.seasonId);
   if (existingObj.seasonId && !recentlyBuiltRisenTeams) {
-    await buildRisenTeams(existingObj.seasonId);
+    try {
+      await buildRisenTeams(existingObj.seasonId);
+    } catch (error) {
+      logger.error(`Failed to build risen teams for season ${existingObj.seasonId}: ${error.message}`);
+    }
   }
 
   const playerGames = await GetDbPlayerGamesByGameId(ToGameId(matchId));

--- a/BackEnd/src/business/season.ts
+++ b/BackEnd/src/business/season.ts
@@ -1,16 +1,27 @@
 import {
   CreateDbSeasonWithProviderId,
   GetDbActiveSeasonsBySeasonIds,
+  GetDbSeasonById,
   GetDbSeasonByName,
-  GetDbSeasons
+  GetDbSeasons,
+  UpdateDbSeasonGoogleSheetId
 } from '../db/season';
 import SeasonModel from '../../../Common/models/season.model';
 import { CreateRiotTournament } from '../external-api/tournament';
 import { GetPlayerSeasons } from './player';
+import { InvalidRequestError } from '../../../Common/errors';
 
 export async function CreateSeason(seasonName: string, providerId: number): Promise<SeasonModel> {
   const tournamentId = await CreateRiotTournament(seasonName, providerId);
   return await CreateDbSeasonWithProviderId(seasonName, tournamentId, providerId);
+}
+
+export async function UpdateSeasonGoogleSheetId(seasonId: number, googleSheetId: string): Promise<SeasonModel> {
+  const season = await GetDbSeasonById(seasonId);
+  if (!season.active) {
+    throw new InvalidRequestError('Cannot update googleSheetId of an inactive season');
+  }
+  return await UpdateDbSeasonGoogleSheetId(seasonId, googleSheetId);
 }
 
 export async function GetSeasons(active: boolean): Promise<SeasonModel[]> {

--- a/BackEnd/src/business/teams.ts
+++ b/BackEnd/src/business/teams.ts
@@ -36,12 +36,14 @@ export async function GetTeamRosterByTeamIdAndSeason(teamId: number, seasonId: n
 export async function buildRisenTeams(seasonId: number) {
   let sheetName = 'Teams and Standings';
   let seasonsWithSheet = await GetDbActiveSeasonWithSheets(seasonId);
+  if (!seasonsWithSheet) {
+    throw new Error(`Season with ID ${seasonId} not found or not configured with Google Sheets`);
+  }
   let sheet = await GetGoogleSheet(seasonsWithSheet.googleSheetId, sheetName);
   let parser: RisenSheetParser = parsers.get(seasonsWithSheet.googleSheetParserType);
 
   if(!parser) {
-    logger.error(`Parser was not configured correctly for the ${seasonsWithSheet.searchname} season`);
-    return;
+    throw new Error(`Parser was not configured correctly for the ${seasonsWithSheet.searchname} season`);
   }
   await buildTeamsForLeague(parser, sheet, seasonsWithSheet.id);
   await SetDBLastTimeActiveSeasonRisenTeamWasBuilt(new Date(), seasonsWithSheet);

--- a/BackEnd/src/db/season.ts
+++ b/BackEnd/src/db/season.ts
@@ -67,3 +67,10 @@ export async function GetDbActiveSeasonsBySeasonIds(seasonIds: number[]): Promis
   await ensureConnection();
   return await SeasonModel.find({ where: { active: true, id: In(seasonIds) } });
 }
+
+export async function UpdateDbSeasonGoogleSheetId(seasonId: number, googleSheetId: string): Promise<SeasonModel> {
+  await ensureConnection();
+  const season = await GetDbSeasonById(seasonId);
+  season.googleSheetId = googleSheetId;
+  return await season.save();
+}

--- a/Common/Interface/Internal/season.ts
+++ b/Common/Interface/Internal/season.ts
@@ -13,10 +13,15 @@ export interface GetSeasonResponse {
   season: SeasonModel;
 }
 
-export interface GetSeasonResponse {
-  season: SeasonModel;
-}
-
 export interface GetSeasonRequest {
   searchName: string;
+}
+
+export interface UpdateSeasonGoogleSheetIdRequest {
+  seasonId: number;
+  googleSheetId: string;
+}
+
+export interface UpdateSeasonGoogleSheetIdResponse {
+  success: boolean;
 }

--- a/Common/Interface/Internal/teams.ts
+++ b/Common/Interface/Internal/teams.ts
@@ -24,3 +24,11 @@ export interface GetTeamRosterRequest {
 export interface GetTeamRosterResponse {
     roster: PlayerTeamModel[]
 }
+
+export interface BuildRisenTeamsRequest {
+    seasonId: number;
+}
+
+export interface BuildRisenTeamsResponse {
+    success: boolean;
+}


### PR DESCRIPTION
Quick API to support adding googleSheetIds from the API instead of only via the DB + some supporting APIs for FE later

FE will be worked on once i get a working DB instance 